### PR TITLE
[BE] SideQuest 엔티티 수정 및 Custom Reposiotry 구현 완료

### DIFF
--- a/server/src/entities/side-quest/side-quest-repository.interface.ts
+++ b/server/src/entities/side-quest/side-quest-repository.interface.ts
@@ -1,0 +1,8 @@
+import { IGenericRepository } from 'src/core/database/generic/generic.repository';
+import { SideQuest } from './side-quest.entity';
+
+export const SIDE_QUEST_REPOSITORY_KEY = 'sideQuestRepositoryKey';
+
+export interface ISideQuestRepository extends IGenericRepository<SideQuest> {
+  findByQuestId(questId: number): Promise<SideQuest[]>;
+}

--- a/server/src/entities/side-quest/side-quest-repository.module.ts
+++ b/server/src/entities/side-quest/side-quest-repository.module.ts
@@ -1,0 +1,14 @@
+import { ClassProvider, Module } from '@nestjs/common';
+import { SIDE_QUEST_REPOSITORY_KEY } from './side-quest-repository.interface';
+import { SideQuestRepository } from './side-quest.repository';
+
+export const sideQuestRepository: ClassProvider = {
+  provide: SIDE_QUEST_REPOSITORY_KEY,
+  useClass: SideQuestRepository,
+};
+
+@Module({
+  providers: [sideQuestRepository],
+  exports: [sideQuestRepository],
+})
+export class SideQuestRepositoryModule {}

--- a/server/src/entities/side-quest/side-quest.entity.ts
+++ b/server/src/entities/side-quest/side-quest.entity.ts
@@ -1,13 +1,19 @@
-import { BaseEntity, Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { Quest } from '../quest/quest.entity';
 import { Status } from '../../common/types/quest/quest.type';
+import { BaseTimeEntity } from 'src/core/database/typeorm/base-time.entity';
 
 @Entity('side_quest')
-export class SideQuest extends BaseEntity {
+export class SideQuest extends BaseTimeEntity {
+  constructor(sideQuestData: Partial<SideQuest>) {
+    super();
+    Object.assign(this, sideQuestData);
+  }
+
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column('int', { nullable: false })
+  @Column({ type: 'int', nullable: false })
   questId: number;
 
   @Column({ type: 'varchar', length: 50, nullable: false })
@@ -16,15 +22,8 @@ export class SideQuest extends BaseEntity {
   @Column({ type: 'enum', name: 'status', enum: Status, default: Status.onProgress })
   status: Status;
 
-  @Column('timestamp', { nullable: false, default: () => 'CURRENT_TIMESTAMP' })
-  createdAt: Date;
-
-  @Column('timestamp', { nullable: false, default: () => 'CURRENT_TIMESTAMP' })
-  updatedAt: Date;
-
   @ManyToOne(() => Quest, (quest) => quest.sideQuests, {
     onDelete: 'CASCADE',
-    onUpdate: 'CASCADE',
   })
   quest: Quest;
 }

--- a/server/src/entities/side-quest/side-quest.repository.ts
+++ b/server/src/entities/side-quest/side-quest.repository.ts
@@ -1,0 +1,17 @@
+import { GenericTypeOrmRepository } from 'src/core/database/typeorm/generic-typeorm.repository';
+import { ISideQuestRepository } from './side-quest-repository.interface';
+import { EntityTarget } from 'typeorm';
+import { SideQuest } from './side-quest.entity';
+
+export class sideQuestRepository
+  extends GenericTypeOrmRepository<SideQuest>
+  implements ISideQuestRepository
+{
+  getName(): EntityTarget<SideQuest> {
+    return SideQuest.name;
+  }
+
+  async findByQuestId(questId: number): Promise<SideQuest[]> {
+    return this.getRepository().find({ where: { questId } });
+  }
+}

--- a/server/src/entities/side-quest/side-quest.repository.ts
+++ b/server/src/entities/side-quest/side-quest.repository.ts
@@ -3,7 +3,7 @@ import { ISideQuestRepository } from './side-quest-repository.interface';
 import { EntityTarget } from 'typeorm';
 import { SideQuest } from './side-quest.entity';
 
-export class sideQuestRepository
+export class SideQuestRepository
   extends GenericTypeOrmRepository<SideQuest>
   implements ISideQuestRepository
 {


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

#### SideQuest 엔티티 수정
- createAt과 updateAt을 BaseTimeEntity로 분리
- SideQuest 인스턴스 생성을 constructor를 이용하여 생성하기
#### SideQuestRepository 구현
- SideQuestRepository 인스턴스를 이용하여 SideQuestRepository 구현

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

#### SideQuest 엔티티 수정
```ts
import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
import { Quest } from '../quest/quest.entity';
import { Status } from '../../common/types/quest/quest.type';
import { BaseTimeEntity } from 'src/core/database/typeorm/base-time.entity';

@Entity('side_quest')
export class SideQuest extends BaseTimeEntity {
  constructor(sideQuestData: Partial<SideQuest>) {
    super();
    Object.assign(this, sideQuestData);
  }

  @PrimaryGeneratedColumn()
  id: number;

  @Column({ type: 'int', nullable: false })
  questId: number;

  @Column({ type: 'varchar', length: 50, nullable: false })
  content: string;

  @Column({ type: 'enum', name: 'status', enum: Status, default: Status.onProgress })
  status: Status;

  @ManyToOne(() => Quest, (quest) => quest.sideQuests, {
    onDelete: 'CASCADE',
  })
  quest: Quest;
}
```
#### SideQuestRepository 구현
```ts
// side-quest-repository.interface.ts
export interface ISideQuestRepository extends IGenericRepository<SideQuest> {
  findByQuestId(questId: number): Promise<SideQuest[]>;
}

// side-quest.repository.ts
export class SideQuestRepository
  extends GenericTypeOrmRepository<SideQuest>
  implements ISideQuestRepository
{
  getName(): EntityTarget<SideQuest> {
    return SideQuest.name;
  }

  async findByQuestId(questId: number): Promise<SideQuest[]> {
    return this.getRepository().find({ where: { questId } });
  }
}
```

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
