### PR TITLE
[BE] Enum 타입 컨벤션 변경 및 User 엔티티의 provider에 Enum 타입 적용

### DIFF
--- a/server/src/common/requests/user/create-social-user.request.ts
+++ b/server/src/common/requests/user/create-social-user.request.ts
@@ -1,4 +1,5 @@
-import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { IsEmail, IsEnum, IsNotEmpty, IsString } from 'class-validator';
+import { UserProvider } from 'src/common/types/user/user.type';
 
 export class CreateSocialUserRequest {
   @IsNotEmpty()
@@ -6,8 +7,8 @@ export class CreateSocialUserRequest {
   email: string;
 
   @IsNotEmpty()
-  @IsString()
-  provider: string;
+  @IsEnum(UserProvider)
+  provider: UserProvider;
 
   @IsNotEmpty()
   @IsString()
@@ -17,7 +18,7 @@ export class CreateSocialUserRequest {
   @IsString()
   nickname: string;
 
-  constructor(email: string, provider: string, providerId: string, nickname: string) {
+  constructor(email: string, provider: UserProvider, providerId: string, nickname: string) {
     this.email = email;
     this.provider = provider;
     this.providerId = providerId;

--- a/server/src/common/types/quest/quest.type.ts
+++ b/server/src/common/types/quest/quest.type.ts
@@ -1,22 +1,22 @@
 export enum Difficulty {
-  Default = 'DEFAULT',
-  Easy = 'EASY',
-  Normal = 'NORMAL',
-  Hard = 'HARD',
+  DEFAULT = 'default',
+  EASY = 'easy',
+  NORMAL = 'normal',
+  HARD = 'hard',
 }
 
 export enum Mode {
-  Main = 'MAIN',
-  Sub = 'SUB',
+  MAIN = 'main',
+  SUB = 'sub',
 }
 
 export enum isHidden {
-  True = 'TRUE',
-  False = 'FALSE',
+  TRUE = 'true',
+  FALSE = 'false',
 }
 
 export enum Status {
-  Completed = 'COMPLETED',
-  Fail = 'FAIL',
-  onProgress = 'ON_PROGRESS',
+  COMPLETED = 'completed',
+  FAIL = 'fail',
+  ON_PROGRESS = 'onProgress',
 }

--- a/server/src/common/types/user/user.type.ts
+++ b/server/src/common/types/user/user.type.ts
@@ -1,0 +1,6 @@
+export enum UserProvider {
+  LOCAL = 'local',
+  GOOGLE = 'google',
+  NAVER = 'naver',
+  KAKAO = 'kakao',
+}

--- a/server/src/core/scheduler/scheduler.service.ts
+++ b/server/src/core/scheduler/scheduler.service.ts
@@ -28,14 +28,14 @@ export class SchedulerService {
 
     const targetQuests = await this.questRepository.find({
       where: {
-        mode: Mode.Main,
-        status: Status.onProgress,
+        mode: Mode.MAIN,
+        status: Status.ON_PROGRESS,
         endDate: dueDate.toISOString().split('T')[0],
       },
       relations: ['sideQuests'],
     });
     const targetSubQuests = await this.questRepository.find({
-      where: { mode: Mode.Sub, status: Status.onProgress },
+      where: { mode: Mode.SUB, status: Status.ON_PROGRESS },
     });
 
     if (targetQuests.length === 0) {
@@ -44,20 +44,20 @@ export class SchedulerService {
     } else {
       for (const quest of targetQuests) {
         const completedSideQuestsCount = quest.sideQuests.filter(
-          (sideQuest) => sideQuest.status === Status.Completed
+          (sideQuest) => sideQuest.status === Status.COMPLETED
         ).length;
 
         if (completedSideQuestsCount > 0) {
-          quest.status = Status.Completed;
+          quest.status = Status.COMPLETED;
           quest.updatedAt = currentDate;
         } else {
-          quest.status = Status.Fail;
+          quest.status = Status.FAIL;
           quest.updatedAt = currentDate;
         }
 
         for (const sideQuest of quest.sideQuests) {
-          if (sideQuest.status === Status.onProgress) {
-            sideQuest.status = Status.Fail;
+          if (sideQuest.status === Status.ON_PROGRESS) {
+            sideQuest.status = Status.FAIL;
             sideQuest.updatedAt = currentDate;
           }
         }
@@ -79,7 +79,7 @@ export class SchedulerService {
       return;
     } else {
       const updatedSubQuests = targetSubQuests.map((it) => {
-        it.status = Status.Fail;
+        it.status = Status.FAIL;
         it.updatedAt = currentDate;
         return it;
       });
@@ -89,7 +89,7 @@ export class SchedulerService {
       for (const quest of updatedSubQuests) {
         const updatePointDto = {
           questId: quest.id,
-          status: Status.Fail,
+          status: Status.FAIL,
         } satisfies UpdatePointDto;
 
         await pointService.updatePoint(quest.userId, updatePointDto);

--- a/server/src/core/strategies/google.strategy.ts
+++ b/server/src/core/strategies/google.strategy.ts
@@ -5,6 +5,7 @@ import { IUserService, USER_SERVICE_KEY } from 'src/modules/user/interfaces/user
 import { CreateSocialUserRequest } from 'src/common/requests/user';
 import { AccessTokenPayload } from 'src/common/dto/token';
 import { AUTH_SERVICE_KEY, IAuthService } from 'src/modules/auth/interfaces/auth-service.interface';
+import { UserProvider } from 'src/common/types/user/user.type';
 
 @Injectable()
 export class GoogleStrategy extends PassportStrategy(Strategy) {
@@ -28,8 +29,13 @@ export class GoogleStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(_accessToken: string, _refreshToken: string, profile: Profile) {
-    const { emails, provider, id, displayName } = profile;
-    const googleUser = new CreateSocialUserRequest(emails[0].value, provider, id, displayName);
+    const { emails, id, displayName } = profile;
+    const googleUser = new CreateSocialUserRequest(
+      emails[0].value,
+      UserProvider.GOOGLE,
+      id,
+      displayName
+    );
 
     try {
       let user = await this.authService.validateSocialUser(googleUser);

--- a/server/src/entities/quest/quest.entity.ts
+++ b/server/src/entities/quest/quest.entity.ts
@@ -29,7 +29,7 @@ export class Quest extends BaseTimeEntity {
   @Column({ type: 'enum', enum: isHidden, nullable: false })
   hidden: isHidden;
 
-  @Column({ type: 'enum', enum: Status, default: Status.onProgress, nullable: false })
+  @Column({ type: 'enum', enum: Status, default: Status.ON_PROGRESS, nullable: false })
   status: Status;
 
   @Column({ type: 'varchar', nullable: false })

--- a/server/src/entities/quest/quest.repository.ts
+++ b/server/src/entities/quest/quest.repository.ts
@@ -10,7 +10,7 @@ export class QuestRepository extends GenericTypeOrmRepository<Quest> implements 
   }
 
   async findMainQuestsByUserId(userId: number, dateString: string): Promise<Quest[]> {
-    return this.baseSelectQueryBuilder(userId, Mode.Main)
+    return this.baseSelectQueryBuilder(userId, Mode.MAIN)
       .leftJoinAndSelect('quest.sideQuests', 'sideQuest')
       .andWhere('quest.startDate <= :dateString', { dateString })
       .andWhere('quest.endDate >= :dateString', { dateString })
@@ -19,18 +19,18 @@ export class QuestRepository extends GenericTypeOrmRepository<Quest> implements 
   }
 
   async findSubQuestsByUserId(userId: number, dateString: string): Promise<Quest[]> {
-    return this.baseSelectQueryBuilder(userId, Mode.Sub)
+    return this.baseSelectQueryBuilder(userId, Mode.SUB)
       .andWhere('quest.startDate = :dateString', { dateString })
       .orderBy('quest.id', 'DESC')
       .getMany();
   }
 
   async findMainQuestById(id: number, userId: number): Promise<Quest> {
-    return this.baseSelectQueryBuilder(userId, Mode.Main).andWhere('qeust.id=:id', { id }).getOne();
+    return this.baseSelectQueryBuilder(userId, Mode.MAIN).andWhere('qeust.id=:id', { id }).getOne();
   }
 
   async findSubQuestById(id: number, userId: number): Promise<Quest> {
-    return this.baseSelectQueryBuilder(userId, Mode.Sub).andWhere('qeust.id=:id', { id }).getOne();
+    return this.baseSelectQueryBuilder(userId, Mode.SUB).andWhere('qeust.id=:id', { id }).getOne();
   }
 
   private baseSelectQueryBuilder(userId: number, mode: Mode): SelectQueryBuilder<Quest> {
@@ -51,7 +51,7 @@ export class QuestRepository extends GenericTypeOrmRepository<Quest> implements 
       'quest.updatedAt',
     ];
 
-    return mode === Mode.Main
+    return mode === Mode.MAIN
       ? [...commonFields, 'quest.difficulty', 'quest.startDate', 'quest.endDate']
       : commonFields;
   }

--- a/server/src/entities/side-quest/side-quest.entity.ts
+++ b/server/src/entities/side-quest/side-quest.entity.ts
@@ -19,7 +19,7 @@ export class SideQuest extends BaseTimeEntity {
   @Column({ type: 'varchar', length: 50, nullable: false })
   content: string;
 
-  @Column({ type: 'enum', name: 'status', enum: Status, default: Status.onProgress })
+  @Column({ type: 'enum', name: 'status', enum: Status, default: Status.ON_PROGRESS })
   status: Status;
 
   @ManyToOne(() => Quest, (quest) => quest.sideQuests, {

--- a/server/src/entities/user/user.entity.ts
+++ b/server/src/entities/user/user.entity.ts
@@ -4,6 +4,7 @@ import { Quest } from '../quest/quest.entity';
 import { ProfilePhoto } from '../profile-photo/profile-photo.entity';
 import { BaseTimeEntity } from 'src/core/database/typeorm/base-time.entity';
 import { RefreshToken } from '../refresh-token/refresh-token.entity';
+import { UserProvider } from 'src/common/types/user/user.type';
 
 @Entity('user')
 @Unique(['email'])
@@ -17,8 +18,8 @@ export class User extends BaseTimeEntity {
   @Column({ type: 'varchar', length: 100, nullable: true })
   password: string | null;
 
-  @Column({ type: 'varchar', length: 50, nullable: true })
-  provider: string | null;
+  @Column({ type: 'enum', nullable: true, enum: UserProvider, default: UserProvider.LOCAL })
+  provider: UserProvider;
 
   @Column({ type: 'varchar', length: 100, nullable: true })
   providerId: string | null;
@@ -51,7 +52,7 @@ export class User extends BaseTimeEntity {
     return user;
   }
 
-  static createSocial(email: string, provider: string, providerId: string): User {
+  static createSocial(email: string, provider: UserProvider, providerId: string): User {
     const user = new User();
     user.email = email;
     user.provider = provider;

--- a/server/src/modules/point/point.service.ts
+++ b/server/src/modules/point/point.service.ts
@@ -39,15 +39,15 @@ export class PointService {
       quest.status = status;
       quest.updatedAt = currentDate;
       const completedSideQuestsCount = quest.sideQuests.filter(
-        (sideQuest) => sideQuest.status === Status.Completed
+        (sideQuest) => sideQuest.status === Status.COMPLETED
       ).length;
 
       const totalPoint =
-        quest.mode === Mode.Main ? completedSideQuestsCount * difficultyPoint : difficultyPoint;
+        quest.mode === Mode.MAIN ? completedSideQuestsCount * difficultyPoint : difficultyPoint;
       userInfo.point +=
-        status === Status.Completed
+        status === Status.COMPLETED
           ? totalPoint
-          : status === Status.onProgress
+          : status === Status.ON_PROGRESS
             ? -totalPoint
             : -difficultyPoint;
 
@@ -66,13 +66,13 @@ export class PointService {
 
   private getPointByDifficulty(difficulty: Difficulty): number {
     switch (difficulty) {
-      case Difficulty.Default:
+      case Difficulty.DEFAULT:
         return 2;
-      case Difficulty.Easy:
+      case Difficulty.EASY:
         return 3;
-      case Difficulty.Normal:
+      case Difficulty.NORMAL:
         return 4;
-      case Difficulty.Hard:
+      case Difficulty.HARD:
         return 5;
       default:
         throw new HttpException('Invalid difficulty', HttpStatus.UNPROCESSABLE_ENTITY);

--- a/server/src/modules/quest/quests.controller.ts
+++ b/server/src/modules/quest/quests.controller.ts
@@ -98,7 +98,7 @@ export class QuestsController {
     const queryDate = query
       ? query.replace(/(\d{4})(\d{2})(\d{2})/g, '$1-$2-$3')
       : new Date().toISOString().split('T')[0];
-    return await this.questsService.findAll(user.id, Mode.Main, queryDate);
+    return await this.questsService.findAll(user.id, Mode.MAIN, queryDate);
   }
 
   @UseGuards(JwtAuthGuard)
@@ -187,7 +187,7 @@ export class QuestsController {
     const queryDate = query
       ? query.replace(/(\d{4})(\d{2})(\d{2})/g, '$1-$2-$3')
       : new Date().toISOString().split('T')[0];
-    return await this.questsService.findAll(user.id, Mode.Sub, queryDate);
+    return await this.questsService.findAll(user.id, Mode.SUB, queryDate);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/server/src/modules/quest/quests.service.ts
+++ b/server/src/modules/quest/quests.service.ts
@@ -29,25 +29,25 @@ export class QuestsService {
       const quest = this.questRepository.create({
         userId: userId,
         title: title,
-        difficulty: mode === Mode.Main ? difficulty : Difficulty.Default,
+        difficulty: mode === Mode.MAIN ? difficulty : Difficulty.DEFAULT,
         mode: mode,
         startDate: startDate,
         endDate: endDate,
         hidden: hidden,
-        status: status ? status : Status.onProgress,
+        status: status ? status : Status.ON_PROGRESS,
         createdAt: currentDate,
         updatedAt: currentDate,
       });
       const savedQuest = await queryRunner.manager.save(quest);
 
-      if (mode === Mode.Main) {
+      if (mode === Mode.MAIN) {
         for (const sideQuest of sideQuests) {
           const { content } = sideQuest;
 
           const side = this.sideQuestRepository.create({
             questId: savedQuest.id,
             content: content,
-            status: Status.onProgress,
+            status: Status.ON_PROGRESS,
             createdAt: currentDate,
             updatedAt: currentDate,
           });
@@ -71,7 +71,7 @@ export class QuestsService {
     const mainOptions: FindManyOptions<Quest> = {
       where: {
         userId: userId,
-        mode: Mode.Main,
+        mode: Mode.MAIN,
         startDate: LessThanOrEqual(queryDate),
         endDate: MoreThanOrEqual(queryDate),
       },
@@ -93,13 +93,13 @@ export class QuestsService {
       ],
     };
     const subOptions: FindManyOptions<Quest> = {
-      where: { userId: userId, mode: Mode.Sub, startDate: queryDate },
+      where: { userId: userId, mode: Mode.SUB, startDate: queryDate },
       order: {
         id: 'DESC',
       },
       select: ['id', 'title', 'hidden', 'status', 'createdAt', 'updatedAt'],
     };
-    const quests = await this.questRepository.find(mode === Mode.Main ? mainOptions : subOptions);
+    const quests = await this.questRepository.find(mode === Mode.MAIN ? mainOptions : subOptions);
 
     if (!quests) {
       throw new HttpException('fail - Quests not found', HttpStatus.NOT_FOUND);
@@ -110,7 +110,7 @@ export class QuestsService {
 
   async findOne(userId: number, questId: number) {
     const options: FindManyOptions<Quest> = {
-      where: { id: questId, userId: userId, mode: Mode.Main },
+      where: { id: questId, userId: userId, mode: Mode.MAIN },
       order: {
         id: 'DESC',
       },

--- a/server/src/modules/user/user.service.ts
+++ b/server/src/modules/user/user.service.ts
@@ -24,6 +24,7 @@ import {
   UpdateUserRequest,
 } from 'src/common/requests/user';
 import { UserResponse } from 'src/common/responses/user';
+import { UserProvider } from 'src/common/types/user/user.type';
 
 @Injectable()
 export class UserService implements IUserService {
@@ -138,7 +139,7 @@ export class UserService implements IUserService {
     return await this.userRepository.save(user);
   }
 
-  private async createSocialUser(email: string, provider: string, providerId: string) {
+  private async createSocialUser(email: string, provider: UserProvider, providerId: string) {
     const newUser = User.createSocial(email, provider, providerId);
     return this.userRepository.save(newUser);
   }


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.
#### Enum 타입 컨벤션 변경
- OAuth로 로그인 시 구글에서 전달받는 데이터와 일치시키기 위해 구글에서 사용하는 컨벤션으로 변경
#### User 엔티티의 provider에 Enum 타입 적용
- 일단 로컬, 구글, 네이버, 카카오를 상정하여 Enum 타입 작성
### 💡 이슈를 처리하면서 추가된 코드가 있어요.
#### Enum 타입 컨벤션 변경
```ts
export enum Difficulty {
  DEFAULT = 'default',
  EASY = 'easy',
  NORMAL = 'normal',
  HARD = 'hard',
}

export enum Mode {
  MAIN = 'main',
  SUB = 'sub',
}
...
```
#### User 엔티티의 provider에 Enum 타입 적용
```ts
export enum UserProvider {
  LOCAL = 'local',
  GOOGLE = 'google',
  NAVER = 'naver',
  KAKAO = 'kakao',
}
```
### 💡 필요한 후속작업이 있어요.

- TypeScript의 Enum 타입에 대해서 알아보고, 개선하기

### 💡 다음 자료를 참고하면 좋아요.

- [Google JavaScript Style Guide](https://google.github.io/styleguide/jsguide.html)

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
