### PR TITLE
[BE] 유저 API 리팩토링

### DIFF
--- a/server/src/common/requests/user/update-profile-photo.request.ts
+++ b/server/src/common/requests/user/update-profile-photo.request.ts
@@ -6,7 +6,6 @@ export class UpdateProfilePhotoRequest {
     description: '프로필 이미지 스트링 형태의 데이터',
     required: false,
   })
-  @IsOptional()
   @IsNotEmpty()
   @IsString()
   profilePhotoUrl: string;

--- a/server/src/common/requests/user/update-user.request.ts
+++ b/server/src/common/requests/user/update-user.request.ts
@@ -17,8 +17,7 @@ export class UpdateUserRequest {
     description: '0 ~ 50 이하 자기소개 글',
     required: false,
   })
-  @IsOptional()
   @IsString()
   @Length(0, 50)
-  intro?: string | null;
+  intro: string;
 }

--- a/server/src/common/responses/user/user.response.ts
+++ b/server/src/common/responses/user/user.response.ts
@@ -1,21 +1,28 @@
-import { User } from '../../../entities/user/user.entity';
+import { Expose, Transform } from 'class-transformer';
 
 export class UserResponse {
+  @Expose()
   readonly id: number;
-  readonly email: string;
-  readonly nickname: string;
-  readonly intro: string | null;
-  readonly point: number;
-  readonly profilePhotoUrl: string | null;
-  readonly level: number;
 
-  constructor(user: User, level: number) {
-    this.id = user.id;
-    this.email = user.email;
-    this.nickname = user.userInfo.nickname;
-    this.intro = user.userInfo.intro;
-    this.point = user.userInfo.point;
-    this.profilePhotoUrl = user.profilePhoto.profilePhotoUrl;
-    this.level = level;
-  }
+  @Expose()
+  readonly email: string;
+
+  @Expose()
+  @Transform(({ obj }) => obj.userInfo.nickname)
+  readonly nickname: string;
+
+  @Expose()
+  @Transform(({ obj }) => obj.userInfo.intro)
+  readonly intro: string | null;
+
+  @Expose()
+  @Transform(({ obj }) => obj.userInfo.point)
+  readonly point: number;
+
+  @Expose()
+  @Transform(({ obj }) => obj.profilePhoto.profilePhotoUrl)
+  readonly profilePhotoUrl: string | null;
+
+  @Expose()
+  readonly level: number;
 }

--- a/server/src/entities/profile-photo/profile-photo.repository.ts
+++ b/server/src/entities/profile-photo/profile-photo.repository.ts
@@ -12,6 +12,11 @@ export class ProfilePhotoRepository
   }
 
   async findOneByUserId(userId: number): Promise<ProfilePhoto> {
-    return this.getRepository().findOneBy({ userId });
+    return this.getRepository().findOne({
+      where: {
+        user: { id: userId },
+      },
+      relations: ['user'],
+    });
   }
 }

--- a/server/src/entities/quest/quest.entity.ts
+++ b/server/src/entities/quest/quest.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, JoinTable, ManyToOne, OneToMany } from 'typeorm';
+import { Column, Entity, ManyToOne, OneToMany } from 'typeorm';
 import { User } from '../user/user.entity';
 import { SideQuest } from '../side-quest/side-quest.entity';
 import { Difficulty, Hidden, Mode, Status } from '../../common/types/quest/quest.type';
@@ -30,7 +30,7 @@ export class Quest extends BaseTimeEntity {
   @Column({ type: 'timestamp' })
   endDate: Date;
 
-  @ManyToOne(() => User)
+  @ManyToOne(() => User, (user) => user.quests)
   user: User;
 
   @OneToMany(() => SideQuest, (sideQuest) => sideQuest.quest, {

--- a/server/src/entities/quest/quest.entity.ts
+++ b/server/src/entities/quest/quest.entity.ts
@@ -30,12 +30,13 @@ export class Quest extends BaseTimeEntity {
   @Column({ type: 'timestamp' })
   endDate: Date;
 
-  @ManyToOne(() => User, (user) => user.quests)
+  @ManyToOne(() => User, (user) => user.quests, {
+    onDelete: 'CASCADE',
+  })
   user: User;
 
   @OneToMany(() => SideQuest, (sideQuest) => sideQuest.quest, {
     cascade: ['insert'],
-    onDelete: 'CASCADE',
   })
   sideQuests: SideQuest[];
 

--- a/server/src/entities/refresh-token/refresh-token.repository.ts
+++ b/server/src/entities/refresh-token/refresh-token.repository.ts
@@ -12,10 +12,15 @@ export class RefreshTokenRepository
   }
 
   findByUserId(userId: number, token: string): Promise<RefreshToken> {
-    return this.getRepository().findOne({ where: { userId, token } });
+    return this.getRepository().findOne({
+      where: { user: { id: userId }, token },
+      relations: ['user'],
+    });
   }
 
   async deleteByUserId(userId: number): Promise<void> {
-    await this.getRepository().delete({ userId });
+    await this.getRepository().delete({
+      user: { id: userId },
+    });
   }
 }

--- a/server/src/entities/user-info/user-info.repository.ts
+++ b/server/src/entities/user-info/user-info.repository.ts
@@ -13,7 +13,7 @@ export class UserInfoRepository
   }
 
   async findByUserId(userId: number): Promise<UserInfo | null> {
-    return this.getRepository().findOne({ where: { userId } });
+    return this.getRepository().findOne({ where: { user: { id: userId } }, relations: ['user'] });
   }
   async findByNickname(nickname: string): Promise<UserInfo | null> {
     return this.getRepository().findOneBy({ nickname });

--- a/server/src/entities/user/user-repository.interface.ts
+++ b/server/src/entities/user/user-repository.interface.ts
@@ -4,6 +4,7 @@ import { User } from './user.entity';
 export const USER_REPOSITORY_KEY = 'USER_REPOSITORY_KEY';
 
 export interface IUserRepository extends IGenericRepository<User> {
+  findById(id: number): Promise<User>;
   findByEmail(email: string): Promise<User | null>;
-  findById(id: number): Promise<User | null>;
+  findUserById(id: number): Promise<User | null>;
 }

--- a/server/src/entities/user/user.entity.ts
+++ b/server/src/entities/user/user.entity.ts
@@ -21,35 +21,22 @@ export class User extends BaseTimeEntity {
   providerId: string | null;
 
   @OneToOne(() => UserInfo, (userInfo) => userInfo.user, {
-    cascade: true,
-    onDelete: 'CASCADE',
+    cascade: ['insert'],
   })
   userInfo: UserInfo;
 
   @OneToOne(() => ProfilePhoto, (ProfilePhoto) => ProfilePhoto.user, {
-    cascade: true,
-    onDelete: 'CASCADE',
+    cascade: ['insert'],
   })
   profilePhoto: ProfilePhoto;
 
-  @OneToMany(() => RefreshToken, (refreshToken) => refreshToken.user, {
-    onDelete: 'CASCADE',
-  })
+  @OneToMany(() => RefreshToken, (refreshToken) => refreshToken.user)
   refreshTokens: RefreshToken[];
 
-  @OneToMany(() => Quest, (quest) => quest.user, {
-    onDelete: 'CASCADE',
-  })
+  @OneToMany(() => Quest, (quest) => quest.user)
   quests: Quest[];
 
   static createLocal(email: string, password: string): User {
-    const user = new User();
-    user.email = email;
-    user.password = password;
-    return user;
-  }
-
-  static create(email: string, password: string): User {
     const user = new User();
     user.email = email;
     user.password = password;
@@ -63,5 +50,13 @@ export class User extends BaseTimeEntity {
     user.provider = provider;
     user.providerId = providerId;
     return user;
+  }
+
+  updateUserInfo(userInfo: UserInfo): void {
+    this.userInfo = userInfo;
+  }
+
+  updateProfilePhoto(profilePhoto: ProfilePhoto): void {
+    this.profilePhoto = profilePhoto;
   }
 }

--- a/server/src/entities/user/user.repository.ts
+++ b/server/src/entities/user/user.repository.ts
@@ -1,18 +1,27 @@
 import { GenericTypeOrmRepository } from 'src/core/database/typeorm/generic-typeorm.repository';
 import { User } from './user.entity';
 import { IUserRepository } from './user-repository.interface';
-import { EntityTarget } from 'typeorm';
+import { EntityTarget, FindOneOptions } from 'typeorm';
 
 export class UserRepository extends GenericTypeOrmRepository<User> implements IUserRepository {
   getName(): EntityTarget<User> {
     return User.name;
   }
 
+  async findById(id: number): Promise<User> {
+    const findOption: FindOneOptions = { where: { id } };
+    return this.getRepository().findOne(findOption);
+  }
+
   async findByEmail(email: string): Promise<User | null> {
     return this.getRepository().findOneBy({ email });
   }
 
-  async findById(id: number): Promise<User | null> {
-    return this.getRepository().findOne({ where: { id } });
+  async findUserById(id: number): Promise<User | null> {
+    const findOption: FindOneOptions = {
+      where: { id },
+      relations: ['userInfo', 'profilePhoto'],
+    };
+    return this.getRepository().findOne(findOption);
   }
 }

--- a/server/src/entities/user/user.repository.ts
+++ b/server/src/entities/user/user.repository.ts
@@ -9,7 +9,7 @@ export class UserRepository extends GenericTypeOrmRepository<User> implements IU
   }
 
   async findById(id: number): Promise<User> {
-    const findOption: FindOneOptions = { where: { id } };
+    const findOption: FindOneOptions = { where: { id }, relations: ['userInfo', 'profilePhoto'] };
     return this.getRepository().findOne(findOption);
   }
 

--- a/server/src/modules/side-quest/side-quest.service.ts
+++ b/server/src/modules/side-quest/side-quest.service.ts
@@ -69,6 +69,4 @@ export class SideQuestService {
       throw new HttpException('사이드 퀘스트 업데이트에 실패하였습니다', HttpStatus.CONFLICT);
     }
   }
-
-  async deleteSideQuests() {}
 }

--- a/server/src/modules/user/user.controller.ts
+++ b/server/src/modules/user/user.controller.ts
@@ -48,10 +48,9 @@ export class UserController {
   @ApiCreatedResponse({ description: 'success' })
   @ApiConflictResponse({ description: '이미 존재하는 회원입니다.' })
   @ApiBody({ type: CreateLocalUserRequest })
-  @UsePipes(ValidationPipe)
   @HttpCode(HttpStatus.CREATED)
-  async signUp(@Body() createUserDto: CreateLocalUserRequest) {
-    await this.userService.localSignUp(createUserDto);
+  async signUp(@Body() request: CreateLocalUserRequest) {
+    await this.userService.localSignUp(request);
     return { message: 'success' };
   }
 
@@ -87,13 +86,12 @@ export class UserController {
   @ApiUnauthorizedResponse({ description: 'Unauthenticated' })
   @ApiForbiddenResponse({ description: 'Fail - Invalid token' })
   @ApiConflictResponse({ description: '닉네임이 이미 사용 중입니다' })
-  @UsePipes(ValidationPipe)
   @HttpCode(HttpStatus.NO_CONTENT)
   async updateUserInfo(
     @CurrentUser() user: AccessTokenPayload,
-    @Body() updateUserRequest: UpdateUserRequest
+    @Body() request: UpdateUserRequest
   ) {
-    await this.userService.updateUserInfoById(user.id, updateUserRequest);
+    await this.userService.updateUserInfoById(user.id, request);
   }
 
   @Patch('me/profile-photo')
@@ -103,13 +101,12 @@ export class UserController {
   @ApiNoContentResponse({ description: '프로필 사진 수정 성공' })
   @ApiUnauthorizedResponse({ description: 'Unauthenticated' })
   @ApiForbiddenResponse({ description: 'Fail - Invalid token' })
-  @UsePipes(ValidationPipe)
   @HttpCode(HttpStatus.NO_CONTENT)
   async updateProfilePhoto(
     @CurrentUser() user: AccessTokenPayload,
-    @Body() updateProfilePhotoRequest: UpdateProfilePhotoRequest
+    @Body() request: UpdateProfilePhotoRequest
   ) {
-    await this.userService.updateProfilePhotoById(user.id, updateProfilePhotoRequest);
+    await this.userService.updateProfilePhotoById(user.id, request);
   }
 
   @Get(':id')

--- a/server/src/modules/user/user.service.ts
+++ b/server/src/modules/user/user.service.ts
@@ -37,46 +37,36 @@ export class UserService implements IUserService {
   ) {}
 
   @Transactional()
-  async localSignUp(createLocalUserRequest: CreateLocalUserRequest): Promise<void> {
-    const { email, password, nickname } = createLocalUserRequest;
+  async localSignUp(request: CreateLocalUserRequest): Promise<void> {
+    const { email, password, nickname } = request;
+    const saltRounds = Number(this.configService.get('SALT_ROUNDS'));
 
+    await this.isExistEmail(email);
+    await this.isExistNickname(nickname);
     try {
-      await this.isExistEmail(email);
-      await this.isExistNickname(nickname);
-
-      const saltRounds = parseInt(this.configService.get<string>('SALT_ROUNDS'));
       const hashedPassword = await encryptValue(password, saltRounds);
-
       const newUser = User.createLocal(email, hashedPassword);
       newUser.updateUserInfo(UserInfo.create(nickname));
       newUser.updateProfilePhoto(ProfilePhoto.create());
-      // // const newUser = User.create(email, hashedPassword);
-      // const newUserInfo = UserInfo.create(nickname);
-      // const newProfilePhoto = ProfilePhoto.create();
-      // newUser.userInfo = newUserInfo;
-      // newUser.profilePhoto = newProfilePhoto;
-      await this.userRepository.save(newUser);
 
-      // const newUser = await this.createLocalUser(email, password);
-      // await this.createUserInfo(newUser.id, nickname);
-      // await this.createProfilePhoto(newUser.id);
-    } catch (err) {
+      await this.userRepository.save(newUser);
+    } catch (error) {
       throw new HttpException('회원가입에 실패하였습니다', HttpStatus.CONFLICT);
     }
   }
 
   @Transactional()
-  async socialSignUp(createSocialUserRequest: CreateSocialUserRequest): Promise<User> {
-    const { email, provider, providerId, nickname } = createSocialUserRequest;
+  async socialSignUp(request: CreateSocialUserRequest): Promise<User> {
+    const { email, provider, providerId, nickname } = request;
+    const uniqueNickname = await this.createUniqueNickname(nickname);
     try {
-      const uniqueNickname = await this.createUniqueNickname(nickname);
-      const newSnsUser = await this.createSocialUser(email, provider, providerId);
-      await this.createUserInfo(newSnsUser.id, uniqueNickname);
-      await this.createProfilePhoto(newSnsUser.id);
+      const newSnsUser = User.createSocial(email, provider, providerId);
+      newSnsUser.updateUserInfo(UserInfo.create(uniqueNickname));
+      newSnsUser.updateProfilePhoto(ProfilePhoto.create());
 
-      return newSnsUser;
-    } catch (err) {
-      throw err;
+      return await this.userRepository.save(newSnsUser);
+    } catch (error) {
+      throw new HttpException('회원가입에 실패하였습니다', HttpStatus.CONFLICT);
     }
   }
 
@@ -117,11 +107,8 @@ export class UserService implements IUserService {
     await this.userInfoRepository.save(userInfo);
   }
 
-  async updateProfilePhotoById(
-    userId: number,
-    updateProfilePhotoRequest: UpdateProfilePhotoRequest
-  ): Promise<void> {
-    const { profilePhotoUrl } = updateProfilePhotoRequest;
+  async updateProfilePhotoById(userId: number, request: UpdateProfilePhotoRequest): Promise<void> {
+    const { profilePhotoUrl } = request;
     const profilePhoto = await this.profilePhotoRepository.findOneByUserId(userId);
     if (!profilePhoto) {
       throw new HttpException('해당 유저 정보가 존재하지 않습니다.', HttpStatus.NOT_FOUND);
@@ -143,28 +130,6 @@ export class UserService implements IUserService {
     if (existingNickname) {
       throw new HttpException('닉네임이 이미 사용 중입니다', HttpStatus.CONFLICT);
     }
-  }
-
-  private async createLocalUser(email: string, password: string): Promise<User> {
-    const saltRounds = parseInt(this.configService.get<string>('SALT_ROUNDS'));
-    const hashedPassword = await encryptValue(password, saltRounds);
-    const user = User.createLocal(email, hashedPassword);
-    return await this.userRepository.save(user);
-  }
-
-  private async createSocialUser(email: string, provider: UserProvider, providerId: string) {
-    const newUser = User.createSocial(email, provider, providerId);
-    return this.userRepository.save(newUser);
-  }
-
-  private async createUserInfo(userId: number, nickname: string): Promise<void> {
-    const userInfo = UserInfo.create(nickname);
-    await this.userInfoRepository.save(userInfo);
-  }
-
-  private async createProfilePhoto(userId: number): Promise<void> {
-    const profilePhoto = ProfilePhoto.create();
-    await this.profilePhotoRepository.save(profilePhoto);
   }
 
   private async createUniqueNickname(nickname: string): Promise<string> {


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

#### 유저 생성 로직 리팩토링
- 기존 로직은 user, userInfo, profilePhoto 엔티티를 전부 생성 후, 저장
- cascade를 활용하여 유저 생성 로직 간결화

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

#### 유저 생성 로직 리팩토링
```ts
  @Transactional()
  async localSignUp(request: CreateLocalUserRequest): Promise<void> {
    const { email, password, nickname } = request;
    const saltRounds = Number(this.configService.get('SALT_ROUNDS'));

    await this.isExistEmail(email);
    await this.isExistNickname(nickname);
    try {
      const hashedPassword = await encryptValue(password, saltRounds);
      const newUser = User.createLocal(email, hashedPassword);
      newUser.updateUserInfo(UserInfo.create(nickname));
      newUser.updateProfilePhoto(ProfilePhoto.create());

      await this.userRepository.save(newUser);
    } catch (error) {
      throw new HttpException('회원가입에 실패하였습니다', HttpStatus.CONFLICT);
    }
  }
```

### ✅ 셀프 체크리스트

- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [ ] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
