### PR TITLE
[BE] 인증 메시지와 토큰 생성 수정

### DIFF
--- a/server/src/common/dto/token/access-token-payload.dto.ts
+++ b/server/src/common/dto/token/access-token-payload.dto.ts
@@ -3,11 +3,4 @@ export class AccessTokenPayload {
     readonly id: number,
     readonly email: string
   ) {}
-
-  toPlain(): { id: number; email: string } {
-    return {
-      id: this.id,
-      email: this.email,
-    };
-  }
 }

--- a/server/src/common/dto/token/refresh-token-payload.dto.ts
+++ b/server/src/common/dto/token/refresh-token-payload.dto.ts
@@ -1,9 +1,3 @@
 export class RefreshTokenPayload {
   constructor(readonly id: number) {}
-
-  toPlain(): { id: number } {
-    return {
-      id: this.id,
-    };
-  }
 }

--- a/server/src/common/types/token/index.ts
+++ b/server/src/common/types/token/index.ts
@@ -1,1 +1,0 @@
-export * from './token.type';

--- a/server/src/common/types/token/token.type.ts
+++ b/server/src/common/types/token/token.type.ts
@@ -1,3 +1,0 @@
-import { AccessTokenPayload, RefreshTokenPayload } from 'src/common/dto/token';
-
-export type TokenPayload = AccessTokenPayload | RefreshTokenPayload;

--- a/server/src/core/strategies/google.strategy.ts
+++ b/server/src/core/strategies/google.strategy.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Profile, Strategy } from 'passport-google-oauth20';
 import { IUserService, USER_SERVICE_KEY } from 'src/modules/user/interfaces/user-service.interface';
@@ -43,8 +43,8 @@ export class GoogleStrategy extends PassportStrategy(Strategy) {
       const payload = new AccessTokenPayload(user.id, user.email);
 
       return payload;
-    } catch (err) {
-      throw err;
+    } catch (error) {
+      throw new UnauthorizedException('Google 계정을 통한 인증에 실패했습니다.');
     }
   }
 }

--- a/server/src/core/strategies/local.strategy.ts
+++ b/server/src/core/strategies/local.strategy.ts
@@ -15,7 +15,7 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
   async validate(email: string, password: string): Promise<AccessTokenPayload> {
     const user = await this.authService.validateLocalUser(email, password);
     if (!user) {
-      throw new UnauthorizedException();
+      throw new UnauthorizedException('로그인에 실패했습니다.');
     }
     const payload = new AccessTokenPayload(user.id, user.email);
     return payload;

--- a/server/src/core/token/interfaces/token-service.interface.ts
+++ b/server/src/core/token/interfaces/token-service.interface.ts
@@ -1,6 +1,5 @@
 import { AccessTokenPayload, RefreshTokenPayload } from 'src/common/dto/token';
 import { AuthTokenResponse } from 'src/common/responses/token';
-import { TokenPayload } from 'src/common/types/token';
 import { RefreshToken } from 'src/entities/refresh-token/refresh-token.entity';
 
 export const TOKEN_SERVICE_KEY = 'tokenServiceKey';

--- a/server/src/core/token/token.service.ts
+++ b/server/src/core/token/token.service.ts
@@ -15,6 +15,7 @@ import {
   IRefreshTokenRepository,
   REFRESH_TOKEN_REPOSITORY_KEY,
 } from 'src/entities/refresh-token/refresh-token-repository.interface';
+import { instanceToPlain } from 'class-transformer';
 
 @Injectable()
 export class TokenService implements ITokenService {
@@ -25,12 +26,13 @@ export class TokenService implements ITokenService {
     private readonly refreshTokenRepository: IRefreshTokenRepository
   ) {}
   async createAccessToken(payload: AccessTokenPayload): Promise<string> {
-    return await this.jwtService.signAsync(payload.toPlain());
+    return await this.jwtService.signAsync(instanceToPlain(payload));
   }
+
   async createRefreshToken(userId: number): Promise<string> {
     const refreshTokenPayload = new RefreshTokenPayload(userId);
 
-    const token = await this.jwtService.signAsync(refreshTokenPayload.toPlain(), {
+    const token = await this.jwtService.signAsync(instanceToPlain(refreshTokenPayload), {
       secret: this.configService.get<string>('REFRESH_TOKEN_SECRET_KEY'),
       expiresIn: this.configService.get<string>('REFRESH_TOKEN_EXPIRES_IN'),
     });
@@ -44,13 +46,13 @@ export class TokenService implements ITokenService {
   async updateRefreshToken(userId: number, refreshToken: RefreshToken): Promise<string> {
     const refreshTokenPayload = new RefreshTokenPayload(userId);
 
-    const token = await this.jwtService.signAsync(refreshTokenPayload.toPlain(), {
+    const token = await this.jwtService.signAsync(instanceToPlain(refreshTokenPayload), {
       secret: this.configService.get<string>('REFRESH_TOKEN_SECRET_KEY'),
       expiresIn: this.configService.get<string>('REFRESH_TOKEN_EXPIRES_IN'),
     });
 
     refreshToken.update(token);
-    this.refreshTokenRepository.save(refreshToken);
+    await this.refreshTokenRepository.save(refreshToken);
 
     return token;
   }
@@ -60,19 +62,18 @@ export class TokenService implements ITokenService {
   }
 
   async refresh(refreshToken: string, payload: AccessTokenPayload): Promise<AuthTokenResponse> {
+    const target = await this.refreshTokenRepository.findByUserId(payload.id, refreshToken);
+
+    if (!target) {
+      throw new HttpException('refreshToken이 존재하지 않습니다', HttpStatus.NOT_FOUND);
+    }
     try {
-      const target = await this.refreshTokenRepository.findByUserId(payload.id, refreshToken);
-
-      if (!target) {
-        throw new HttpException('refreshToken이 존재하지 않습니다', HttpStatus.NOT_FOUND);
-      }
-
       const newAccessToken = await this.createAccessToken(payload);
       const newRefreshToken = await this.updateRefreshToken(payload.id, target);
 
       return new AuthTokenResponse(newAccessToken, newRefreshToken);
     } catch (error) {
-      throw new UnauthorizedException();
+      throw new UnauthorizedException('토큰 갱신에 실패했습니다.');
     }
   }
 
@@ -81,7 +82,7 @@ export class TokenService implements ITokenService {
       const secretKey = this.configService.get<string>('REFRESH_TOKEN_SECRET_KEY');
       return await this.jwtService.verifyAsync(refreshToken, { secret: secretKey });
     } catch (error) {
-      throw new UnauthorizedException();
+      throw new UnauthorizedException('토큰 검증에 실패했습니다.');
     }
   }
 }

--- a/server/src/modules/auth/auth.service.ts
+++ b/server/src/modules/auth/auth.service.ts
@@ -58,14 +58,13 @@ export class AuthService implements IAuthService {
   }
 
   async refresh(refreshToken: string): Promise<AuthTokenResponse> {
+    const decodedToken = await this.tokenService.verifiedRefreshToken(refreshToken);
+    const user = await this.userService.findUserById(decodedToken.id);
     try {
-      const decodedToken = await this.tokenService.verifiedRefreshToken(refreshToken);
-      const user = await this.userService.findUserById(decodedToken.id);
-
       const payload = new AccessTokenPayload(user.id, user.email);
       return this.tokenService.refresh(refreshToken, payload);
-    } catch {
-      throw new UnauthorizedException();
+    } catch (error) {
+      throw new UnauthorizedException('토큰 재발급에 실패했습니다.');
     }
   }
 }

--- a/server/src/modules/auth/interfaces/auth-service.interface.ts
+++ b/server/src/modules/auth/interfaces/auth-service.interface.ts
@@ -6,7 +6,7 @@ import { User } from 'src/entities/user/user.entity';
 export const AUTH_SERVICE_KEY = 'authServiceKey';
 
 export interface IAuthService {
-  validateLocalUser(email: string, password: string): Promise<User | null>;
+  validateLocalUser(email: string, password: string): Promise<Omit<User, 'password'> | null>;
   validateSocialUser(createSocialUserRequest: CreateSocialUserRequest): Promise<User | null>;
   login(payload: AccessTokenPayload): Promise<AuthTokenResponse>;
   logout(userId: number): Promise<void>;

--- a/server/src/modules/user/user.service.ts
+++ b/server/src/modules/user/user.service.ts
@@ -24,7 +24,6 @@ import {
   UpdateUserRequest,
 } from 'src/common/requests/user';
 import { UserResponse } from 'src/common/responses/user';
-import { UserProvider } from 'src/common/types/user/user.type';
 import { plainToInstance } from 'class-transformer';
 
 @Injectable()


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

#### 에러 메시지 수정
- 토큰 생성 및 인증 에러 관련 메시지 자세히 보내기
#### 토큰 생성 수정
- `payload`를 plain object로 변경 후 인자로 보내기

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

#### 토큰 생성 수정
```ts
// token.service.ts
  async createAccessToken(payload: AccessTokenPayload): Promise<string> {
    return await this.jwtService.signAsync(instanceToPlain(payload));
  }
```

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
