### PR TITLE
[BE] ValueTransformer를 활용하여 데이터 변환하기

### DIFF
--- a/server/src/common/requests/quest/create-quest.request.ts
+++ b/server/src/common/requests/quest/create-quest.request.ts
@@ -1,17 +1,9 @@
 import { Difficulty, Hidden, Mode } from '@common/types/quest/quest.type';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import {
-  IsArray,
-  IsDate,
-  IsEnum,
-  IsNotEmpty,
-  IsString,
-  ValidateIf,
-  ValidateNested,
-} from 'class-validator';
+import { IsArray, IsEnum, IsNotEmpty, IsString, ValidateIf, ValidateNested } from 'class-validator';
 import { CreateSideQuestRequest } from './create-side-quest.request';
-import { TransformDateToUTC } from '@core/decorators/transform-date-to-utc.decorator';
+import { IsOnlyDate } from '@core/decorators/is-only-date.decorator';
 
 export class CreateQuestRequest {
   @ApiProperty({
@@ -69,10 +61,9 @@ export class CreateQuestRequest {
     description: '퀘스트 시작일',
     required: true,
   })
-  @TransformDateToUTC({ option: 'start' })
   @IsNotEmpty()
-  @IsDate()
-  startDate: Date;
+  @IsOnlyDate()
+  startDate: string;
 
   @ApiProperty({
     example: '2024-05-15',
@@ -80,10 +71,8 @@ export class CreateQuestRequest {
     required: true,
   })
   @IsNotEmpty()
-  @TransformDateToUTC({ option: 'end' })
-  @IsNotEmpty()
-  @IsDate()
-  endDate: Date;
+  @IsOnlyDate()
+  endDate: string;
 
   constructor() {}
 }

--- a/server/src/common/requests/quest/update-main-quest.request.ts
+++ b/server/src/common/requests/quest/update-main-quest.request.ts
@@ -1,9 +1,9 @@
 import { Difficulty, Hidden } from '@common/types/quest/quest.type';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsArray, IsDate, IsEnum, IsNotEmpty, IsString } from 'class-validator';
+import { IsArray, IsEnum, IsNotEmpty, IsString } from 'class-validator';
 import { UpdateSideQuestRequest } from './update-side-quest.request';
-import { TransformDateToUTC } from '@core/decorators/transform-date-to-utc.decorator';
+import { IsOnlyDate } from '@core/decorators/is-only-date.decorator';
 
 export class UpdateMainQuestRequest {
   @ApiProperty({
@@ -50,20 +50,18 @@ export class UpdateMainQuestRequest {
     description: '퀘스트 시작일',
     required: true,
   })
-  @TransformDateToUTC({ option: 'start' })
   @IsNotEmpty()
-  @IsDate()
-  startDate: Date;
+  @IsOnlyDate()
+  startDate: string;
 
   @ApiProperty({
     example: '2024-05-15',
     description: '퀘스트 종료일',
     required: true,
   })
-  @TransformDateToUTC({ option: 'end' })
   @IsNotEmpty()
-  @IsDate()
-  endDate: Date;
+  @IsOnlyDate()
+  endDate: string;
 
   constructor() {}
 }

--- a/server/src/common/utils/date.util.ts
+++ b/server/src/common/utils/date.util.ts
@@ -12,7 +12,7 @@ export const DEFAULT_TIMEZONE = 'Asia/Seoul';
  * @param dateString 'YYYY-MM-DD' 형식의 날짜 문자열
  * @returns UTC 기준의 시작 시간
  */
-export const toUTCStartOfDay = (dateString: string): Date => {
+export const toStartUTC = (dateString: string): Date => {
   return dayjs.tz(dateString, DEFAULT_TIMEZONE).startOf('day').utc().toDate();
 };
 
@@ -21,8 +21,12 @@ export const toUTCStartOfDay = (dateString: string): Date => {
  * @param dateString 'YYYY-MM-DD' 형식의 날짜 문자열
  * @returns UTC 기준의 종료 시간
  */
-export const toUTCEndOfDay = (dateString: string): Date => {
+export const toEndUTC = (dateString: string): Date => {
   return dayjs.tz(dateString, DEFAULT_TIMEZONE).endOf('day').utc().toDate();
+};
+
+export const toDateString = (date: Date): string => {
+  return dayjs(date).tz(DEFAULT_TIMEZONE).format('YYYYMMDD');
 };
 
 export const getUTCMidnightFromKRTime = (): Date => {

--- a/server/src/core/database/typeorm/transformer/end-date.transformer.ts
+++ b/server/src/core/database/typeorm/transformer/end-date.transformer.ts
@@ -1,0 +1,11 @@
+import { toDateString, toEndUTC } from '@common/utils/date.util';
+import { ValueTransformer } from 'typeorm';
+
+export class EndDateTransformer implements ValueTransformer {
+  to(value: string): Date {
+    return toEndUTC(value);
+  }
+  from(value: Date): string {
+    return toDateString(value);
+  }
+}

--- a/server/src/core/database/typeorm/transformer/start-date.transformer.ts
+++ b/server/src/core/database/typeorm/transformer/start-date.transformer.ts
@@ -1,0 +1,11 @@
+import { toDateString, toStartUTC } from '@common/utils/date.util';
+import { ValueTransformer } from 'typeorm';
+
+export class StartDateTransformer implements ValueTransformer {
+  to(value: string): Date {
+    return toStartUTC(value);
+  }
+  from(value: Date): string {
+    return toDateString(value);
+  }
+}

--- a/server/src/core/decorators/is-only-date.decorator.ts
+++ b/server/src/core/decorators/is-only-date.decorator.ts
@@ -1,0 +1,26 @@
+import { ValidationOptions, registerDecorator } from 'class-validator';
+import dayjs from 'dayjs';
+
+const DATE_REGEX = /^\d{4}(-)((0[1-9])|(1[0-2]))(-)([12]\d|3[0-1])$/;
+
+export function IsOnlyDate(validationOptions?: ValidationOptions) {
+  return function (object: Record<string, any>, propertyName: string) {
+    registerDecorator({
+      name: 'IsOnlyDate',
+      target: object.constructor,
+      propertyName: propertyName,
+      constraints: [],
+      options: {
+        message: 'Please provide only date like YYYY-MM-DD',
+        ...validationOptions,
+      },
+      validator: {
+        validate(value: any): boolean {
+          if (typeof value !== 'string' && !DATE_REGEX.test(value)) return false;
+
+          return dayjs(value, 'YYYY-MM-DD', true).isValid();
+        },
+      },
+    });
+  };
+}

--- a/server/src/core/decorators/transform-date-to-utc.decorator.ts
+++ b/server/src/core/decorators/transform-date-to-utc.decorator.ts
@@ -1,19 +1,19 @@
-import { toUTCEndOfDay, toUTCStartOfDay } from '@common/utils/date.util';
-import { BadRequestException } from '@nestjs/common';
-import { Transform } from 'class-transformer';
-import dayjs from 'dayjs';
+// import { toUTCEndOfDay, toUTCStartOfDay } from '@common/utils/date.util';
+// import { BadRequestException } from '@nestjs/common';
+// import { Transform } from 'class-transformer';
+// import dayjs from 'dayjs';
 
-export type TransformDateOptions = {
-  option: 'start' | 'end';
-};
+// export type TransformDateOptions = {
+//   option: 'start' | 'end';
+// };
 
-export function TransformDateToUTC({ option }: TransformDateOptions): PropertyDecorator {
-  return Transform(({ value }) => {
-    const regex = /^\d{4}-\d{2}-\d{2}$/;
-    if (typeof value !== 'string' && !regex.test(value) && !dayjs(value).isValid()) {
-      throw new BadRequestException(`Please provide only date like 'YYYY-MM-DD'`);
-    }
+// export function TransformDateToUTC({ option }: TransformDateOptions): PropertyDecorator {
+//   return Transform(({ value }) => {
+//     const regex = /^\d{4}-\d{2}-\d{2}$/;
+//     if (typeof value !== 'string' && !regex.test(value) && !dayjs(value).isValid()) {
+//       throw new BadRequestException(`Please provide only date like 'YYYY-MM-DD'`);
+//     }
 
-    return option === 'start' ? toUTCStartOfDay(value) : toUTCEndOfDay(value);
-  });
-}
+//     return option === 'start' ? toUTCStartOfDay(value) : toUTCEndOfDay(value);
+//   });
+// }

--- a/server/src/entities/quest/quest.entity.ts
+++ b/server/src/entities/quest/quest.entity.ts
@@ -3,6 +3,8 @@ import { User } from '../user/user.entity';
 import { SideQuest } from '../side-quest/side-quest.entity';
 import { Difficulty, Hidden, Mode, Status } from '../../common/types/quest/quest.type';
 import { BaseTimeEntity } from 'src/core/database/typeorm/base-time.entity';
+import { StartDateTransformer } from '@core/database/typeorm/transformer/start-date.transformer';
+import { EndDateTransformer } from '@core/database/typeorm/transformer/end-date.transformer';
 
 @Entity('quest')
 export class Quest extends BaseTimeEntity {
@@ -24,10 +26,10 @@ export class Quest extends BaseTimeEntity {
   @Column({ type: 'enum', enum: Status, default: Status.ON_PROGRESS })
   status: Status;
 
-  @Column({ type: 'timestamp' })
+  @Column({ type: 'timestamp', precision: 3, transformer: new StartDateTransformer() })
   startDate: Date;
 
-  @Column({ type: 'timestamp' })
+  @Column({ type: 'timestamp', precision: 3, transformer: new EndDateTransformer() })
   endDate: Date;
 
   @ManyToOne(() => User, (user) => user.quests, {
@@ -44,8 +46,8 @@ export class Quest extends BaseTimeEntity {
     userId: number,
     title: string,
     difficulty: Difficulty,
-    startDate: Date,
-    endDate: Date,
+    startDate: string,
+    endDate: string,
     hidden: Hidden
   ): Quest {
     const quest = new Quest();
@@ -53,8 +55,8 @@ export class Quest extends BaseTimeEntity {
     quest.title = title;
     quest.difficulty = difficulty;
     quest.mode = Mode.MAIN;
-    quest.startDate = startDate;
-    quest.endDate = endDate;
+    quest.startDate = quest.startDateTransformer.to(startDate);
+    quest.endDate = quest.endDateTransformer.to(endDate);
     quest.hidden = hidden;
     quest.status = Status.ON_PROGRESS;
 
@@ -64,8 +66,8 @@ export class Quest extends BaseTimeEntity {
   static createSubQuest(
     userId: number,
     title: string,
-    startDate: Date,
-    endDate: Date,
+    startDate: string,
+    endDate: string,
     hidden: Hidden
   ): Quest {
     const quest = new Quest();
@@ -73,8 +75,8 @@ export class Quest extends BaseTimeEntity {
     quest.title = title;
     quest.difficulty = Difficulty.DEFAULT;
     quest.mode = Mode.SUB;
-    quest.startDate = startDate;
-    quest.endDate = endDate;
+    quest.startDate = quest.startDateTransformer.to(startDate);
+    quest.endDate = quest.endDateTransformer.to(endDate);
     quest.hidden = hidden;
     quest.status = Status.ON_PROGRESS;
 
@@ -85,14 +87,14 @@ export class Quest extends BaseTimeEntity {
     title: string,
     difficulty: Difficulty,
     hidden: Hidden,
-    startDate: Date,
-    endDate: Date
+    startDate: string,
+    endDate: string
   ): void {
     this.title = title;
     this.difficulty = difficulty;
     this.hidden = hidden;
-    this.startDate = startDate;
-    this.endDate = endDate;
+    this.startDate = this.startDateTransformer.to(startDate);
+    this.endDate = this.endDateTransformer.to(endDate);
   }
 
   updateStatus(status: Status): void {
@@ -107,4 +109,7 @@ export class Quest extends BaseTimeEntity {
     this.title = title;
     this.hidden = hidden;
   }
+
+  private startDateTransformer = new StartDateTransformer();
+  private endDateTransformer = new EndDateTransformer();
 }

--- a/server/src/modules/quest/services/quest.service.ts
+++ b/server/src/modules/quest/services/quest.service.ts
@@ -8,12 +8,12 @@ import {
   UpdateMainQuestRequest,
   UpdateQuestStatusRequest,
 } from '@common/requests/quest';
-import { toUTCStartOfDay } from '@common/utils/date.util';
 import { MainQuestResponse } from '@common/responses/quest';
 import { SubQuestResponse } from '@common/responses/quest/sub-quest.response';
 import { plainToInstance } from 'class-transformer';
 import { UpdateSubQuestRequest } from '@common/requests/quest/update-sub-quest.request';
 import { SideQuestService } from '@modules/side-quest/side-quest.service';
+import { toStartUTC } from '@common/utils/date.util';
 
 @Injectable()
 export class QuestService {
@@ -55,7 +55,7 @@ export class QuestService {
   }
 
   async findMainQuests(userId: number, dateString: string): Promise<MainQuestResponse[]> {
-    const date = toUTCStartOfDay(dateString);
+    const date = toStartUTC(dateString);
     const quests = await this.questRepository.findMainQuests(userId, date);
     if (!quests) {
       throw new HttpException('퀘스트가 존재하지 않습니다', HttpStatus.NOT_FOUND);
@@ -64,7 +64,7 @@ export class QuestService {
   }
 
   async findSubQuests(userId: number, dateString: string): Promise<SubQuestResponse[]> {
-    const date = toUTCStartOfDay(dateString);
+    const date = toStartUTC(dateString);
     const quests = await this.questRepository.findSubQuests(userId, date);
     if (!quests) {
       throw new HttpException('서브 퀘스트가 존재하지 않습니다', HttpStatus.NOT_FOUND);


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

#### 문자열 형태의 날짜를 Date 타입으로 변환하기
- request와 response로 전달할 때, 시작과 끝나는 날짜는 문자열 날짜(`'2024-08-08'`)로 보내줘야함
- 데이터베이스에 저장할 때는 Date 타입으로 저장
- 따라서, 데이터베이스와 엔티티 사이에서 데이터 변환을 해주기 위해 사용

#### 특정 날짜 검증하기
- `'2024-08-08'`과 같은 형태로 보내졌는지 검증하기
### 💡 이슈를 처리하면서 추가된 코드가 있어요.

#### StartDateTransformer와 EndDateTransformer
```ts
export class StartDateTransformer implements ValueTransformer {
  to(value: string): Date {
    return toStartUTC(value);
  }
  from(value: Date): string {
    return toDateString(value);
  }
}

export class EndDateTransformer implements ValueTransformer {
  to(value: string): Date {
    return toEndUTC(value);
  }
  from(value: Date): string {
    return toDateString(value);
  }
}
```

#### 특정 날짜 검증하기
```ts
const DATE_REGEX = /^\d{4}(-)((0[1-9])|(1[0-2]))(-)([12]\d|3[0-1])$/;

export function IsOnlyDate(validationOptions?: ValidationOptions) {
  return function (object: Record<string, any>, propertyName: string) {
    registerDecorator({
      name: 'IsOnlyDate',
      target: object.constructor,
      propertyName: propertyName,
      constraints: [],
      options: {
        message: 'Please provide only date like YYYY-MM-DD',
        ...validationOptions,
      },
      validator: {
        validate(value: any): boolean {
          if (typeof value !== 'string' && !DATE_REGEX.test(value)) return false;

          return dayjs(value, 'YYYY-MM-DD', true).isValid();
        },
      },
    });
  };
}
```

### 💡 필요한 후속작업이 있어요.

- 엔티티를 생성하는 static 메서드에서 startDate와 endDate를 설정하는 방법 변경하기

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
