### PR TITLE
[BE] 예외 처리 로깅 관련 메서드에서 인수 위치 수정

### DIFF
--- a/server/src/core/filters/all-exceptions.filter.ts
+++ b/server/src/core/filters/all-exceptions.filter.ts
@@ -1,6 +1,5 @@
 import {
   ArgumentsHost,
-  BadRequestException,
   Catch,
   ExceptionFilter,
   HttpException,
@@ -38,7 +37,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
       message
     );
 
-    this.exceptionLogging(exceptionResponse, detail, args, stack);
+    this.exceptionLogging(exceptionResponse, detail, stack, args);
 
     res.status(statusCode).json(exceptionResponse);
   }


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

#### 예외 처리 로깅 관련 메서드에서 인수 위치 수정
- error stack 제대로 전달되도록 수정
### 💡 이슈를 처리하면서 추가된 코드가 있어요.

#### 예외 처리 로깅 메서드
```ts
// all-exceptions.filter.ts
...
    this.exceptionLogging(exceptionResponse, detail, stack, args);
...
  private exceptionLogging(
    exceptionResponse: ExceptionResponse,
    detail: string | Array<object>,
    stack: string,
    args?: object
  ): void {
    if (exceptionResponse.statusCode >= HttpStatus.INTERNAL_SERVER_ERROR) {
      this.logger.error({ ...exceptionResponse, detail, args, stack });
    } else {
      this.logger.warn({ ...exceptionResponse, detail, stack });
    }
  }

```

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
