### PR TITLE
[FE] 메인 페이지 수정

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ThemeProvider } from 'styled-components';
 import { theme } from './styles/theme';
 import { GlobalStyle } from './styles/globalstyles';
@@ -8,7 +7,7 @@ import ReactQueryProvider from './provider/queryProvider';
 
 function App() {
   return (
-    <ReactQueryProvider>
+    <ReactQueryProvider showDevTools={process.env.NODE_ENV === 'development'}>
       <ThemeProvider theme={theme}>
         <GlobalStyle />
         <RouterProvider router={router} />

--- a/client/src/api/quests.api.ts
+++ b/client/src/api/quests.api.ts
@@ -1,7 +1,7 @@
 import { CreateSubQuestProps } from '@/components/modals/CreateSubQuestModal';
 import { SubQuestModifyProps } from '@/components/modals/SubQuestModal';
 import { API_END_POINT } from '@/constant/api';
-import { Quest, SubQuest, QuestStatus } from '@/models/quest.model';
+import { Quest, SubQuest, QuestStatus, MainQuest } from '@/models/quest.model';
 
 import { httpClient } from '@/utils/axios';
 
@@ -32,17 +32,19 @@ export const deleteMainQuest = async (id: number) => {
 };
 
 export const getMainQuest = async (param: GetSubQuestParam) => {
-  const response = await httpClient.get<Quest[]>(API_END_POINT.MAIN_QUEST, { params: param });
+  const response = await httpClient.get<MainQuest[]>(API_END_POINT.MAIN_QUEST, { params: param });
   return response.data;
 };
 
 export const getFindOneMainQuest = async (id: number) => {
-  const response = await httpClient.get<Quest>(API_END_POINT.MAIN_QUEST + `/${id}`);
+  const response = await httpClient.get<MainQuest>(API_END_POINT.MAIN_QUEST + `/${id}`);
   return response.data;
 };
 
-export const modiSideQuest = async (param: number, status: QuestStatus) => {
-  const response = await httpClient.patch(API_END_POINT.SIDE_QUEST + `/${param}`, { status });
+export const modiSideQuest = async (questId: number, sideQuestId: number, status: QuestStatus) => {
+  const response = await httpClient.patch(`${API_END_POINT.SIDE_QUEST(questId)}/${sideQuestId}`, {
+    status,
+  });
   return response.data;
 };
 

--- a/client/src/components/common/Header.tsx
+++ b/client/src/components/common/Header.tsx
@@ -10,7 +10,7 @@ const Header: React.FC<HeaderProps> = ({ title }) => {
   return (
     <HeaderStyle>
       <LogoImage src={Logo} alt="InGame Logo" />
-      <Title text={title} size="medium" />
+      <Title text={title} size="medium" color="blue" />
     </HeaderStyle>
   );
 };

--- a/client/src/components/common/Title.tsx
+++ b/client/src/components/common/Title.tsx
@@ -3,19 +3,20 @@ import styled from 'styled-components';
 interface TitleProps {
   text: string;
   size: 'large' | 'medium' | 'small';
+  color: 'blue' | 'black';
 }
 
-const Title = ({ text, size }: TitleProps) => {
+const Title = ({ text, size, color }: TitleProps) => {
   return (
-    <TitleStyle size={size}>
+    <TitleStyle size={size} color={color}>
       <h1>{text}</h1>
     </TitleStyle>
   );
 };
 
-const TitleStyle = styled.div<Pick<TitleProps, 'size'>>`
+const TitleStyle = styled.div<Omit<TitleProps, 'text'>>`
   font-size: ${({ theme, size }) => theme.font[size]};
-  color: ${({ theme }) => theme.color.blue};
+  color: ${({ theme, color }) => theme.color[color]};
   font-family: 'Pretendard700';
   display: flex;
   justify-content: center;

--- a/client/src/components/modals/ChangeProfileImageModal/ChangeProfileImageModal.tsx
+++ b/client/src/components/modals/ChangeProfileImageModal/ChangeProfileImageModal.tsx
@@ -22,7 +22,7 @@ const ChangeProfileImageModal = ({ handleModal, currentProfile }: ChangeProfileI
       <CloseBtnWrapperStyle>
         <CloseButton onClick={() => handleModal(false)} />
       </CloseBtnWrapperStyle>
-      <Title text="프로필 이미지 변경" size="medium"></Title>
+      <Title text="프로필 이미지 변경" size="medium" color="black"></Title>
       <ProfileImageListStyle>
         <ImageBadge
           imgSrc={defaultProfile}

--- a/client/src/components/quests/MainBox.tsx
+++ b/client/src/components/quests/MainBox.tsx
@@ -38,9 +38,16 @@ const MainBox = ({ content, date, refetchMainBoxData }: MainBoxProps) => {
     if (date === formattedDate(new Date())) {
       let message = '';
       let newStatus = '';
-      if (content.status === 'ON_PROGRESS') {
+      const completedSideQuests = sideQuests.filter(
+        (sideQuest) => sideQuest.status === 'COMPLETED'
+      ).length;
+
+      if (content.status === 'ON_PROGRESS' && completedSideQuests > 0) {
         message = '퀘스트를 완료하시겠습니까?';
         newStatus = 'COMPLETED';
+      } else if (content.status === 'ON_PROGRESS' && completedSideQuests === 0) {
+        showAlert('최소 1개 이상의 사이드 퀘스트를 완료해야 합니다.');
+        return;
       } else if (content.status === 'COMPLETED') {
         message = '퀘스트를 진행중으로 변경하시겠습니까?';
         newStatus = 'ON_PROGRESS';

--- a/client/src/components/quests/MainBox.tsx
+++ b/client/src/components/quests/MainBox.tsx
@@ -7,7 +7,6 @@ import SideBox from './SideBox';
 import { MainQuest, QuestStatus, SideContent } from '@/models/quest.model';
 import { useNavigate } from 'react-router-dom';
 import { useMainQuest } from '@/hooks/useMainQuest';
-import { formattedDate } from '@/utils/formatter';
 import { useMessage } from '@/hooks/useMessage';
 import { useSideQuest } from '@/hooks/useSideQuest';
 
@@ -35,35 +34,32 @@ const MainBox = ({ content, date, refetchMainBoxData }: MainBoxProps) => {
   }
 
   const handleChangeStatus = () => {
-    if (date === formattedDate(new Date())) {
-      let message = '';
-      let newStatus = '';
-      const completedSideQuests = sideQuests.filter(
-        (sideQuest) => sideQuest.status === 'COMPLETED'
-      ).length;
+    let message = '';
+    let newStatus = '';
+    const completedSideQuests = sideQuests.filter(
+      (sideQuest) => sideQuest.status === 'COMPLETED'
+    ).length;
 
-      if (content.status === 'ON_PROGRESS' && completedSideQuests > 0) {
-        message = '퀘스트를 완료하시겠습니까?';
-        newStatus = 'COMPLETED';
-      } else if (content.status === 'ON_PROGRESS' && completedSideQuests === 0) {
-        showAlert('최소 1개 이상의 사이드 퀘스트를 완료해야 합니다.');
-        return;
-      } else if (content.status === 'COMPLETED') {
-        message = '퀘스트를 진행중으로 변경하시겠습니까?';
-        newStatus = 'ON_PROGRESS';
-      } else {
-        return;
-      }
-
-      showConfirm(message, () => {
-        content.status = newStatus as QuestStatus;
-        modifyMainQuestStatus({ id: content.id, status: content.status }).then(() => {
-          refetchMainBoxData();
-        });
-      });
+    if (content.status === 'ON_PROGRESS' && completedSideQuests === 0) {
+      showAlert('최소 1개 이상의 사이드 퀘스트를 완료해야 합니다.');
+      return;
+    } else if (content.status === 'ON_PROGRESS' && completedSideQuests > 0) {
+      message = '퀘스트를 완료하시겠습니까?';
+      newStatus = 'COMPLETED';
+    } else if (content.status === 'COMPLETED') {
+      message = '퀘스트를 진행중으로 변경하시겠습니까?';
+      newStatus = 'ON_PROGRESS';
     } else {
-      showAlert('당일 퀘스트만 변경 가능합니다');
+      showAlert('실패한 퀘스트를 수정할 수 없습니다.');
+      return;
     }
+
+    showConfirm(message, () => {
+      content.status = newStatus as QuestStatus;
+      modifyMainQuestStatus({ id: content.id, status: content.status }).then(() => {
+        refetchMainBoxData();
+      });
+    });
   };
 
   const handleNavigate = (event: React.MouseEvent) => {
@@ -78,13 +74,8 @@ const MainBox = ({ content, date, refetchMainBoxData }: MainBoxProps) => {
   };
 
   const handleSideQuestStatusChange = (sideQuest: SideContent) => {
-    if (date !== formattedDate(new Date())) {
-      showAlert('당일 퀘스트만 변경 가능합니다');
-      return;
-    }
-
-    if (content.status === 'COMPLETED') {
-      showAlert('완료된 퀘스트의 사이드 퀘스트는 변경할 수 없습니다');
+    if (content.status === 'COMPLETED' || content.status === 'FAIL') {
+      showAlert('퀘스트를 변경할 수 없습니다');
       return;
     }
 

--- a/client/src/components/quests/MainBox.tsx
+++ b/client/src/components/quests/MainBox.tsx
@@ -74,13 +74,17 @@ const MainBox = ({ content, date, refetchMainBoxData }: MainBoxProps) => {
 
   const handleToggleAccordion = (event: React.MouseEvent) => {
     event.stopPropagation();
-    if (content.status === 'COMPLETED') return;
     setIsAccordion((prevState) => !prevState);
   };
 
   const handleSideQuestStatusChange = (sideQuest: SideContent) => {
     if (date !== formattedDate(new Date())) {
       showAlert('당일 퀘스트만 변경 가능합니다');
+      return;
+    }
+
+    if (content.status === 'COMPLETED') {
+      showAlert('완료된 퀘스트의 사이드 퀘스트는 변경할 수 없습니다');
       return;
     }
 
@@ -133,6 +137,7 @@ const MainBox = ({ content, date, refetchMainBoxData }: MainBoxProps) => {
                   checked={sideQuest.status === 'COMPLETED'}
                   onClick={() => handleSideQuestStatusChange(sideQuest)}
                   content={sideQuest.content}
+                  disabled={content.status === 'COMPLETED'}
                 />
               ) : null
             )}

--- a/client/src/components/quests/MainBox.tsx
+++ b/client/src/components/quests/MainBox.tsx
@@ -11,8 +11,7 @@ import { useMainQuest } from '@/hooks/useMainQuest';
 import { formattedDate } from '@/utils/formatter';
 import { useMessage } from '@/hooks/useMessage';
 import { BASE_KEY } from '@/constant/queryKey';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { getFindOneMainQuest } from '@/api/quests.api';
+import { useQueryClient } from '@tanstack/react-query';
 
 interface MainQuest extends Quest {
   sideQuests: SideContent[];
@@ -37,10 +36,11 @@ const MainBox = ({ content, date, refetchMainBoxData }: MainBoxProps) => {
   const [sideQuests, setSideQuests] = useState(mainContent.sideQuests);
   const fraction = `${sideQuests.filter((item: Quest) => item.status === 'COMPLETED').length} / ${mainContent.sideQuests.length}`;
 
-  const { data, isLoading, error } = useQuery({
-    queryKey: [BASE_KEY.QUEST, content.id],
-    queryFn: () => getFindOneMainQuest(content.id),
-  });
+  // const { data, isLoading, error } = useQuery({
+  //   queryKey: [BASE_KEY.QUEST, content.id],
+  //   queryFn: () => getFindOneMainQuest(content.id),
+  // });
+  const { mainQuest } = useMainQuest(content.id);
 
   if (!mainContent) {
     return null; // mainContent가 없으면 렌더링하지 않음
@@ -62,8 +62,7 @@ const MainBox = ({ content, date, refetchMainBoxData }: MainBoxProps) => {
 
       showConfirm(message, () => {
         mainContent.status = newStatus;
-        modifyMainQuestStatus({ id: mainContent.id, status: mainContent.status })
-        .then(() => {
+        modifyMainQuestStatus({ id: mainContent.id, status: mainContent.status }).then(() => {
           refetchMainBoxData();
         });
       });
@@ -83,7 +82,7 @@ const MainBox = ({ content, date, refetchMainBoxData }: MainBoxProps) => {
   const handleNavigate = (event: React.MouseEvent) => {
     event.stopPropagation();
     if (mainContent.status === 'COMPLETED') return;
-    navigate(`/editquest/${mainContent.id}`, { state: { data: data, date } });
+    navigate(`/editquest/${mainContent.id}`, { state: { data: mainQuest, date } });
   };
 
   const handleToggleAccordion = (event: React.MouseEvent) => {
@@ -96,7 +95,7 @@ const MainBox = ({ content, date, refetchMainBoxData }: MainBoxProps) => {
     <>
       {mainContent ? (
         <MainBoxContainer>
-          <MainBoxStyle status={mainContent.status} onClick={handleChangeStatus}>
+          <MainBoxStyle $status={mainContent.status} onClick={handleChangeStatus}>
             <header className="aFContainer">
               <button className="aButton" onClick={handleToggleAccordion}>
                 {isAccordion ? <MdArrowDropUp size={30} /> : <MdArrowDropDown size={30} />}
@@ -171,13 +170,13 @@ const MainBoxContainer = styled.div`
   align-items: center;
 `;
 
-const MainBoxStyle = styled.div<{ status: QuestStatus }>`
+const MainBoxStyle = styled.div<{ $status: QuestStatus }>`
   width: 100%;
   height: 55px;
 
-  background: ${({ theme, status }) => theme.statusColor[status]};
-  color: ${({ theme, status }) => status !== 'ON_PROGRESS' && theme.color.grayDark};
-  text-decoration: ${({ status }) => status !== 'ON_PROGRESS' && 'line-through'};
+  background: ${({ theme, $status }) => theme.statusColor[$status]};
+  color: ${({ theme, $status }) => $status !== 'ON_PROGRESS' && theme.color.grayDark};
+  text-decoration: ${({ $status }) => $status !== 'ON_PROGRESS' && 'line-through'};
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1);
   border-radius: ${({ theme }) => theme.borderRadius.medium};
 

--- a/client/src/components/quests/MainBox.tsx
+++ b/client/src/components/quests/MainBox.tsx
@@ -10,7 +10,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useMainQuest } from '@/hooks/useMainQuest';
 import { formattedDate } from '@/utils/formatter';
 import { useMessage } from '@/hooks/useMessage';
-import { BASE_KEY } from '@/constant/queryKey';
+import { BASE_KEY, QUEST } from '@/constant/queryKey';
 import { useQueryClient } from '@tanstack/react-query';
 
 interface MainQuest extends Quest {
@@ -25,8 +25,8 @@ export interface MainBoxProps {
 
 const MainBox = ({ content, date, refetchMainBoxData }: MainBoxProps) => {
   const location = useLocation();
-  const updatedData = location.state?.updatedData;
-  const mainContent = updatedData || content;
+  const updatedData: MainQuest | undefined = location.state?.updatedData;
+  const mainContent: MainQuest = updatedData || content;
   const { modifyMainQuestStatus, patchSideMutation } = useMainQuest();
   const { showConfirm, showAlert } = useMessage();
   const navigate = useNavigate();
@@ -34,12 +34,8 @@ const MainBox = ({ content, date, refetchMainBoxData }: MainBoxProps) => {
   const [isAccordion, setisAccordion] = useState(false);
   const [checked, setChecked] = useState(Array(sideQuestList.length).fill(false));
   const [sideQuests, setSideQuests] = useState(mainContent.sideQuests);
-  const fraction = `${sideQuests.filter((item: Quest) => item.status === 'COMPLETED').length} / ${mainContent.sideQuests.length}`;
+  const fraction = `${sideQuests.filter((item) => item.status === 'COMPLETED').length} / ${mainContent.sideQuests.length}`;
 
-  // const { data, isLoading, error } = useQuery({
-  //   queryKey: [BASE_KEY.QUEST, content.id],
-  //   queryFn: () => getFindOneMainQuest(content.id),
-  // });
   const { mainQuest } = useMainQuest(content.id);
 
   if (!mainContent) {
@@ -61,7 +57,7 @@ const MainBox = ({ content, date, refetchMainBoxData }: MainBoxProps) => {
       }
 
       showConfirm(message, () => {
-        mainContent.status = newStatus;
+        mainContent.status = newStatus as QuestStatus;
         modifyMainQuestStatus({ id: mainContent.id, status: mainContent.status }).then(() => {
           refetchMainBoxData();
         });
@@ -136,7 +132,7 @@ const MainBox = ({ content, date, refetchMainBoxData }: MainBoxProps) => {
                             handleCheckboxClick(index);
 
                             queryClient.setQueryData(
-                              [BASE_KEY.QUEST, mainContent.id],
+                              [...QUEST.GET_SIDEQUEST, mainContent.id],
                               (oldData: Quest) => {
                                 return {
                                   ...oldData,

--- a/client/src/components/quests/SideBox.tsx
+++ b/client/src/components/quests/SideBox.tsx
@@ -5,18 +5,23 @@ interface SideBoxProps {
   checked: boolean;
   onClick: () => void;
   content: string;
+  disabled: boolean;
 }
 
-const SideBox: React.FC<SideBoxProps> = ({ isAccordion, checked, onClick, content }) => {
+const SideBox: React.FC<SideBoxProps> = ({ isAccordion, checked, onClick, content, disabled }) => {
   return (
-    <SideBoxStyle className={`sideBox ${isAccordion ? 'show' : 'hide'}`} onClick={onClick}>
-      <input type="checkbox" checked={checked} readOnly />
+    <SideBoxStyle
+      className={`sideBox ${isAccordion ? 'show' : 'hide'}`}
+      onClick={onClick}
+      $disabled={disabled}
+    >
+      <input type="checkbox" checked={checked} readOnly disabled={disabled} />
       <h2 className="sTitle">{content}</h2>
     </SideBoxStyle>
   );
 };
 
-const SideBoxStyle = styled.div`
+const SideBoxStyle = styled.div<{ $disabled: boolean }>`
   position: relative;
 
   display: flex;
@@ -43,8 +48,11 @@ const SideBoxStyle = styled.div`
     opacity: 1;
   }
 
+  cursor: ${({ $disabled }) => ($disabled ? 'default' : 'pointer')};
+  opacity: ${({ $disabled }) => ($disabled ? 0.7 : 1)};
+
   .cBox {
-    cursor: pointer;
+    cursor: ${({ $disabled }) => ($disabled ? 'default' : 'pointer')};
   }
 `;
 

--- a/client/src/components/quests/SideBox.tsx
+++ b/client/src/components/quests/SideBox.tsx
@@ -9,11 +9,9 @@ interface SideBoxProps {
 
 const SideBox: React.FC<SideBoxProps> = ({ isAccordion, checked, onClick, content }) => {
   return (
-    <SideBoxStyle className={`sideBox ${isAccordion ? 'show' : 'hide'}`}>
-      <label className='cBox'>
-        <input type='checkbox' checked={checked} onChange={onClick} />
-      </label>
-      <h2 className='sTitle'>{content}</h2>
+    <SideBoxStyle className={`sideBox ${isAccordion ? 'show' : 'hide'}`} onClick={onClick}>
+      <input type="checkbox" checked={checked} readOnly />
+      <h2 className="sTitle">{content}</h2>
     </SideBoxStyle>
   );
 };
@@ -31,7 +29,9 @@ const SideBoxStyle = styled.div`
   border-radius: ${({ theme }) => theme.borderRadius.medium};
   gap: 20px;
 
-  transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out;
+  transition:
+    opacity 0.3s ease-in-out,
+    transform 0.3s ease-in-out;
   transform: translateY(-100%);
   max-height: 0;
   overflow: hidden;

--- a/client/src/components/quests/SubBox.tsx
+++ b/client/src/components/quests/SubBox.tsx
@@ -44,7 +44,7 @@ const SubBox = ({ content }: SubBoxProps) => {
   };
 
   return (
-    <SubBoxStyle status={content.status}>
+    <SubBoxStyle $status={content.status}>
       <div onClick={handleChangeStatue} className="clickDiv">
         <h2>{content.title}</h2>
         <button onClick={handleEdit} className="EditBtn">
@@ -63,13 +63,13 @@ const SubBox = ({ content }: SubBoxProps) => {
   );
 };
 
-const SubBoxStyle = styled.div<{ status: QuestStatus }>`
+const SubBoxStyle = styled.div<{ $status: QuestStatus }>`
   width: 100%;
   height: 50px;
 
-  background: ${({ theme, status }) => theme.statusColor[status]};
-  color: ${({ theme, status }) => status !== 'ON_PROGRESS' && theme.color.grayDark};
-  text-decoration: ${({ status }) => status !== 'ON_PROGRESS' && 'line-through'};
+  background: ${({ theme, $status }) => theme.statusColor[$status]};
+  color: ${({ theme, $status }) => $status !== 'ON_PROGRESS' && theme.color.grayDark};
+  text-decoration: ${({ $status }) => $status !== 'ON_PROGRESS' && 'line-through'};
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1);
   border-radius: ${({ theme }) => theme.borderRadius.medium};
 

--- a/client/src/components/quests/SubBox.tsx
+++ b/client/src/components/quests/SubBox.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 import { QuestStatus, SubQuest } from '@/models/quest.model';
 import { useSubQuest } from '@/hooks/useSubQuest';
 import { useMessage } from '@/hooks/useMessage';
-import { formattedDate } from '@/utils/formatter';
 import { BsThreeDots } from 'react-icons/bs';
 import SubQuestModal from '../modals/SubQuestModal';
 import { useState } from 'react';
@@ -17,25 +16,22 @@ const SubBox = ({ content }: SubBoxProps) => {
   const [open, setOpen] = useState(false);
 
   const handleChangeStatue = () => {
-    if (date === formattedDate(new Date())) {
-      let message = '';
-      let status = content.status;
-      if (content.status === 'ON_PROGRESS') {
-        message = '퀘스트를 완료하시겠습니까?';
-        status = 'COMPLETED';
-      } else if (content.status === 'COMPLETED') {
-        message = '퀘스트를 진행중으로 변경하시겠습니까?';
-        status = 'ON_PROGRESS';
-      } else {
-        return;
-      }
-
-      showConfirm(message, () => {
-        modifySubQuestStatus({ id: content.id, status: status });
-      });
+    let message = '';
+    let status = content.status;
+    if (content.status === 'ON_PROGRESS') {
+      message = '퀘스트를 완료하시겠습니까?';
+      status = 'COMPLETED';
+    } else if (content.status === 'COMPLETED') {
+      message = '퀘스트를 진행중으로 변경하시겠습니까?';
+      status = 'ON_PROGRESS';
     } else {
-      showAlert('당일 퀘스트만 변경 가능합니다');
+      showAlert('실패한 퀘스트를 수정할 수 없습니다');
+      return;
     }
+
+    showConfirm(message, () => {
+      modifySubQuestStatus({ id: content.id, status: status });
+    });
   };
 
   const handleEdit = (event: React.MouseEvent) => {

--- a/client/src/constant/api.ts
+++ b/client/src/constant/api.ts
@@ -20,7 +20,7 @@ export const API_END_POINT = {
   // EDIT_MAIN_QUEST
   MAIN_QUEST: '/quests/main',
   // SIDE_QUEST
-  SIDE_QUEST: '/quests/side',
+  SIDE_QUEST: (questId: number) => `/quests/${questId}/side`,
   //POINT
   POINT: '/point',
 };

--- a/client/src/constant/queryKey.ts
+++ b/client/src/constant/queryKey.ts
@@ -1,3 +1,5 @@
+import { QuestMode } from '@/models/quest.model';
+
 export const BASE_KEY = {
   USER: 'USER',
   QUEST: 'QUEST',
@@ -9,8 +11,8 @@ export const USER = {
 };
 
 export const QUEST = {
-  GET_SUBQUEST: [BASE_KEY.QUEST],
-  GET_MAINQUEST: [BASE_KEY.QUEST],
+  GET_SUBQUEST: [BASE_KEY.QUEST, 'SUB'],
+  GET_MAINQUEST: [BASE_KEY.QUEST, 'MAIN'],
 };
 
 export const RANK = {

--- a/client/src/hooks/useMainQuest.ts
+++ b/client/src/hooks/useMainQuest.ts
@@ -6,7 +6,6 @@ import {
   getMainQuest,
   modiMainQuest,
   modiQuestStatus,
-  modiSideQuest,
 } from '@/api/quests.api';
 import { QUEST } from '@/constant/queryKey';
 import { QUERYSTRING } from '@/constant/queryString';
@@ -16,7 +15,6 @@ import {
   QuestDifficulty,
   QuestHiddenType,
   QuestMode,
-  QuestStatus,
   SideContent,
 } from '@/models/quest.model';
 import { formattedDate } from '@/utils/formatter';
@@ -26,11 +24,7 @@ import { useForm } from 'react-hook-form';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useMessage } from '@/hooks/useMessage';
 
-export interface EditMainQuestQuestProps extends Quest {
-  sideQuests: SideContent[];
-}
-
-export interface CreateMainQuestProps extends Quest {
+export interface CreateMainQuestProps {
   title: string;
   difficulty: QuestDifficulty;
   mode: QuestMode;
@@ -165,7 +159,7 @@ export const useEditMainQuestForm = (content: MainQuest, date: string) => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const { register, control, handleSubmit } = useForm<EditMainQuestQuestProps>();
+  const { register, control, handleSubmit } = useForm<MainQuest>();
 
   const editQuestMutation = useMutation({
     mutationFn: (variable: Quest) => {

--- a/client/src/hooks/useMainQuest.ts
+++ b/client/src/hooks/useMainQuest.ts
@@ -8,9 +8,10 @@ import {
   modiQuestStatus,
   modiSideQuest,
 } from '@/api/quests.api';
-import { BASE_KEY, QUEST } from '@/constant/queryKey';
+import { QUEST } from '@/constant/queryKey';
 import { QUERYSTRING } from '@/constant/queryString';
 import {
+  MainQuest,
   Quest,
   QuestDifficulty,
   QuestHiddenType,
@@ -74,8 +75,12 @@ export const useMainQuest = (questId?: number) => {
     },
   });
 
+  const modifyMainQuestStatus = (data: ModifyQuestStatusProps) => {
+    return modifyQuestStatusMutation.mutateAsync(data);
+  };
+
   const modifyQuestStatusMutation = useMutation({
-    mutationFn: modiQuestStatus,
+    mutationFn: (data: ModifyQuestStatusProps) => modiQuestStatus(data),
     onSuccess() {
       queryClient.invalidateQueries({
         queryKey: [...QUEST.GET_MAINQUEST, params.get(QUERYSTRING.DATE)],
@@ -84,26 +89,12 @@ export const useMainQuest = (questId?: number) => {
     onError(err) {},
   });
 
-  const modifyMainQuestStatus = (data: ModifyQuestStatusProps) => {
-    return modifyQuestStatusMutation.mutateAsync(data);
-  };
-
-  const patchSideMutation = useMutation({
-    mutationFn: ({ param, status }: { param: number; status: QuestStatus }) =>
-      modiSideQuest(param, status),
-    onSuccess(res) {},
-    onError(err) {
-      navigate('/error');
-    },
-  });
-
   return {
     mainQuests,
     isMainQuestsLoading,
     mainQuest,
     isMainQuestLoading,
     modifyMainQuestStatus,
-    patchSideMutation,
     deleteMainQuestsMutation,
     date,
   };
@@ -163,7 +154,7 @@ export const useCreateMainQuestForm = () => {
   };
 };
 
-export const useEditMainQuestForm = (content: Quest, date: string) => {
+export const useEditMainQuestForm = (content: MainQuest, date: string) => {
   const [startDate, setStartDate] = useState(content.startDate);
   const [endDate, setEndDate] = useState(content.endDate);
   const [title, setTitle] = useState(content.title);
@@ -207,7 +198,9 @@ export const useEditMainQuestForm = (content: Quest, date: string) => {
             ...newData,
           })
         );
-        queryClient.invalidateQueries({ queryKey: [...QUEST.GET_MAINQUEST, date], exact: true });
+        queryClient.invalidateQueries({
+          queryKey: [...QUEST.GET_MAINQUEST, date],
+        });
         navigate('/', { state: { updatedData: newData } });
       },
     });
@@ -240,7 +233,7 @@ export const useConfirmDelete = (content: Quest) => {
     const message = '정말 삭제하시겠습니까?';
     showConfirm(message, () => {
       if (content && content.id !== undefined) {
-        deleteMainQuestsMutation.mutate(content.id);
+        deleteMainQuestsMutation.mutateAsync(content.id);
       }
     });
   };

--- a/client/src/hooks/useMainQuest.ts
+++ b/client/src/hooks/useMainQuest.ts
@@ -112,12 +112,15 @@ export const useMainQuest = (questId?: number) => {
 export const useCreateMainQuestForm = () => {
   const [isPrivate, setIsPrivate] = useState(false);
   const [isDifficulty, setIsDifficulty] = useState(0);
-  const [startDate, setStartDate] = useState('');
+  const [startDate, setStartDate] = useState(formattedDate(new Date()));
   const [endDate, setEndDate] = useState('');
   const [plusQuest, setPlusQuest] = useState(1);
   const [minusQuest, setMinusQuest] = useState(0);
-  const today = new Date().toISOString().substring(0, 10);
+  const today = formattedDate(new Date());
   const navigate = useNavigate();
+
+  console.log('plusQuest:', plusQuest);
+  console.log('minusQuest:', minusQuest);
 
   const { register, control, handleSubmit } = useForm<CreateMainQuestProps>();
 

--- a/client/src/hooks/useMainQuest.ts
+++ b/client/src/hooks/useMainQuest.ts
@@ -57,7 +57,7 @@ export const useMainQuest = (questId?: number) => {
     enabled: !!questId,
   });
 
-  const DeleteMainQuestsMutation = useMutation({
+  const deleteMainQuestsMutation = useMutation({
     mutationFn: (id: number) => deleteMainQuest(id),
     onSuccess: async (_, deletedId) => {
       queryClient.removeQueries({
@@ -104,7 +104,7 @@ export const useMainQuest = (questId?: number) => {
     isMainQuestLoading,
     modifyMainQuestStatus,
     patchSideMutation,
-    DeleteMainQuestsMutation,
+    deleteMainQuestsMutation,
     date,
   };
 };
@@ -118,10 +118,6 @@ export const useCreateMainQuestForm = () => {
   const [minusQuest, setMinusQuest] = useState(0);
   const today = formattedDate(new Date());
   const navigate = useNavigate();
-
-  console.log('plusQuest:', plusQuest);
-  console.log('minusQuest:', minusQuest);
-
   const { register, control, handleSubmit } = useForm<CreateMainQuestProps>();
 
   const onSubmit = handleSubmit((data) => {
@@ -131,13 +127,13 @@ export const useCreateMainQuestForm = () => {
         isDifficulty === 0 ? 'EASY' : isDifficulty === 1 ? 'NORMAL' : ('HARD' as QuestDifficulty);
       const mode = 'MAIN' as QuestMode;
       const newData = { ...data, hidden, difficulty: difficulty, mode: mode };
-      CreateQuestMutation.mutate(newData);
+      createMainQuestMutation.mutate(newData);
     } else {
       alert('사이드 퀘스트를 추가해주세요.');
     }
   });
 
-  const CreateQuestMutation = useMutation({
+  const createMainQuestMutation = useMutation({
     mutationFn: createMainQuest,
     onSuccess(res) {
       navigate('/');
@@ -180,7 +176,7 @@ export const useEditMainQuestForm = (content: Quest, date: string) => {
 
   const { register, control, handleSubmit } = useForm<EditMainQuestQuestProps>();
 
-  const EditQuestMutation = useMutation({
+  const editQuestMutation = useMutation({
     mutationFn: (variable: Quest) => {
       const { id, ...rest } = variable;
       return modiMainQuest(id, rest);
@@ -202,13 +198,16 @@ export const useEditMainQuestForm = (content: Quest, date: string) => {
     const { id, ...rest } = data;
     const newData = { id, ...rest, hidden, sideQuests: updatedSideQuests };
 
-    EditQuestMutation.mutate(newData, {
+    editQuestMutation.mutate(newData, {
       onSuccess: () => {
-        queryClient.setQueryData([BASE_KEY.QUEST, content.id], (oldData: Quest | undefined) => ({
-          ...oldData,
-          ...newData,
-        }));
-        queryClient.invalidateQueries({ queryKey: [BASE_KEY.QUEST, date], exact: true });
+        queryClient.setQueryData(
+          [...QUEST.GET_MAINQUEST, content.id],
+          (oldData: Quest | undefined) => ({
+            ...oldData,
+            ...newData,
+          })
+        );
+        queryClient.invalidateQueries({ queryKey: [...QUEST.GET_MAINQUEST, date], exact: true });
         navigate('/', { state: { updatedData: newData } });
       },
     });
@@ -235,13 +234,13 @@ export const useEditMainQuestForm = (content: Quest, date: string) => {
 
 export const useConfirmDelete = (content: Quest) => {
   const { showConfirm } = useMessage();
-  const { DeleteMainQuestsMutation } = useMainQuest();
+  const { deleteMainQuestsMutation } = useMainQuest();
 
   const handleDeleteBtn = () => {
     const message = '정말 삭제하시겠습니까?';
     showConfirm(message, () => {
       if (content && content.id !== undefined) {
-        DeleteMainQuestsMutation.mutate(content.id);
+        deleteMainQuestsMutation.mutate(content.id);
       }
     });
   };

--- a/client/src/hooks/useSideQuest.ts
+++ b/client/src/hooks/useSideQuest.ts
@@ -1,0 +1,46 @@
+import { modiSideQuest } from '@/api/quests.api';
+import { QUEST } from '@/constant/queryKey';
+import { MainQuest, QuestStatus } from '@/models/quest.model';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { useMessage } from './useMessage';
+
+export const useSideQuest = () => {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { showAlert } = useMessage();
+
+  const patchSideMutation = useMutation({
+    mutationFn: ({
+      questId,
+      sideQuestId,
+      status,
+    }: {
+      questId: number;
+      sideQuestId: number;
+      status: QuestStatus;
+    }) => modiSideQuest(questId, sideQuestId, status),
+    onSuccess: (_, { questId, sideQuestId, status }) => {
+      queryClient.setQueryData(
+        [...QUEST.GET_MAINQUEST, questId],
+        (oldData: MainQuest | undefined) => {
+          if (!oldData) return oldData;
+          return {
+            ...oldData,
+            sideQuests: oldData.sideQuests.map((sideQuest) =>
+              sideQuest.id === sideQuestId ? { ...sideQuest, status } : sideQuest
+            ),
+          };
+        }
+      );
+    },
+    onError(err) {
+      navigate('/error');
+      showAlert('퀘스트 상태 변경에 실패했습니다. 다시 시도해주세요.');
+    },
+  });
+
+  return {
+    patchSideMutation,
+  };
+};

--- a/client/src/hooks/useSubQuest.ts
+++ b/client/src/hooks/useSubQuest.ts
@@ -8,27 +8,24 @@ import {
 } from '@/api/quests.api';
 import { CreateSubQuestProps } from '@/components/modals/CreateSubQuestModal';
 import { SubQuestModifyProps } from '@/components/modals/SubQuestModal';
-import { BASE_KEY, QUEST } from '@/constant/queryKey';
+import { QUEST } from '@/constant/queryKey';
 import { QUERYSTRING } from '@/constant/queryString';
 import { formattedDate } from '@/utils/formatter';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useMessage } from './useMessage';
 
 export const useSubQuest = () => {
   const location = useLocation();
   const params = new URLSearchParams(location.search);
-
   const { showConfirm } = useMessage();
-
   const queryClient = useQueryClient();
+  const date = params.get(QUERYSTRING.DATE) || formattedDate(new Date());
+  const navigate = useNavigate();
 
-  const { data: subQuestList, isLoading: isSubLoading } = useQuery({
-    queryKey: [QUEST.GET_SUBQUEST, params.get(QUERYSTRING.DATE)],
-    queryFn: () =>
-      getSubQuest({
-        date: params.get(QUERYSTRING.DATE) || formattedDate(new Date()),
-      }),
+  const { data: subQuests, isLoading: isSubLoading } = useQuery({
+    queryKey: [...QUEST.GET_SUBQUEST, date],
+    queryFn: () => getSubQuest({ date }),
   });
 
   const modifySubQuest = async (data: SubQuestModifyProps) => {
@@ -36,10 +33,10 @@ export const useSubQuest = () => {
   };
 
   const modifySubQuestMutation = useMutation({
-    mutationFn: modiSubQuest,
+    mutationFn: (data: SubQuestModifyProps) => modiSubQuest(data),
     onSuccess() {
       queryClient.invalidateQueries({
-        queryKey: [QUEST.GET_SUBQUEST, params.get(QUERYSTRING.DATE)],
+        queryKey: [...QUEST.GET_SUBQUEST, date],
       });
     },
     onError(err) {},
@@ -50,10 +47,10 @@ export const useSubQuest = () => {
   };
 
   const modifyQuestStatusMutation = useMutation({
-    mutationFn: modiQuestStatus,
+    mutationFn: (data: ModifyQuestStatusProps) => modiQuestStatus(data),
     onSuccess() {
       queryClient.invalidateQueries({
-        queryKey: [QUEST.GET_SUBQUEST, params.get(QUERYSTRING.DATE)],
+        queryKey: [...QUEST.GET_SUBQUEST, date],
       });
     },
     onError(err) {},
@@ -64,13 +61,15 @@ export const useSubQuest = () => {
   };
 
   const createSubQuestMutation = useMutation({
-    mutationFn: addSubQuest,
+    mutationFn: (data: CreateSubQuestProps) => addSubQuest(data),
     onSuccess() {
       queryClient.invalidateQueries({
-        queryKey: [QUEST.GET_SUBQUEST, params.get(QUERYSTRING.DATE)],
+        queryKey: [...QUEST.GET_SUBQUEST, date],
       });
     },
-    onError(err) {},
+    onError(err) {
+      navigate('/error');
+    },
   });
 
   const deleteSubQuest = async (id: number) => {
@@ -80,18 +79,16 @@ export const useSubQuest = () => {
   };
 
   const deleteSubQuestMutation = useMutation({
-    mutationFn: delSubQuest,
+    mutationFn: (id: number) => delSubQuest(id),
     onSuccess() {
       queryClient.invalidateQueries({
-        queryKey: [QUEST.GET_SUBQUEST, params.get(QUERYSTRING.DATE)],
+        queryKey: [...QUEST.GET_SUBQUEST, date],
       });
     },
   });
 
-  const date = params.get(QUERYSTRING.DATE) || formattedDate(new Date());
-
   return {
-    quest: subQuestList,
+    subQuests,
     isSubLoading,
     modifySubQuest,
     modifySubQuestStatus,

--- a/client/src/layout/Layout.tsx
+++ b/client/src/layout/Layout.tsx
@@ -17,7 +17,7 @@ export const LayoutStyle = styled.div`
   padding: 1.5rem;
   justify-content: flex-start;
   align-items: center;
-  width: 400px;
+  width: 480px;
   height: 100vh;
   border: 1px solid ${({ theme }) => theme.color.grayNormal};
   border-radius: ${({ theme }) => theme.borderRadius.large};

--- a/client/src/models/quest.model.ts
+++ b/client/src/models/quest.model.ts
@@ -3,13 +3,16 @@ export interface Quest {
   title: string;
   difficulty: QuestDifficulty;
   mode: QuestMode;
-  sideQuests: SideContent[];
   startDate: string;
   endDate: string;
   hidden: QuestHiddenType;
   status: QuestStatus;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface MainQuest extends Quest {
+  sideQuests: SideContent[];
 }
 
 export interface SideContent {

--- a/client/src/pages/CreateMainQuest.tsx
+++ b/client/src/pages/CreateMainQuest.tsx
@@ -48,7 +48,7 @@ const CreateMainQuest = () => {
           <QuestInputBox placeholder="퀘스트 제목" {...register('title')} />
           <QuestButtonContainer>
             <Button
-              type='button'
+              type="button"
               className={`easyButton ${isDifficulty === 0 ? 'isActive' : ''}`}
               onClick={() => setIsDifficulty(0)}
               children={'EASY'}
@@ -56,7 +56,7 @@ const CreateMainQuest = () => {
               color={'white'}
             />
             <Button
-              type='button'
+              type="button"
               className={`normalButton ${isDifficulty === 1 ? 'isActive' : ''}`}
               onClick={() => setIsDifficulty(1)}
               children={'NORMAL'}
@@ -64,7 +64,7 @@ const CreateMainQuest = () => {
               color={'white'}
             />
             <Button
-              type='button'
+              type="button"
               className={`hardButton ${isDifficulty === 2 ? 'isActive' : ''}`}
               onClick={() => setIsDifficulty(2)}
               children={'HARD'}
@@ -114,6 +114,7 @@ const CreateMainQuest = () => {
             <input
               className="endDate"
               type="date"
+              value={endDate || ''}
               {...register('endDate', {
                 required: true,
                 onChange: (e) => setEndDate(e.target.value),

--- a/client/src/pages/EditMainQuest.tsx
+++ b/client/src/pages/EditMainQuest.tsx
@@ -36,7 +36,7 @@ const EditMainQuestQuest = () => {
   return (
     <>
       <CloseButton onClick={() => navigate('/')} />
-      <EditMainQuestQuestStyle>
+      <EditMainQuestStyle>
         <header>
           <p>메인 퀘스트 수정</p>
           <div className="lockIcons">
@@ -57,7 +57,7 @@ const EditMainQuestQuest = () => {
           />
           <QuestButtonContainer>
             <Button
-              type='button'
+              type="button"
               className={`easyButton ${isDifficulty === 'EASY' ? 'isActive' : ''}`}
               onClick={() => setIsDifficulty('EASY')}
               children={'EASY'}
@@ -65,7 +65,7 @@ const EditMainQuestQuest = () => {
               color={'white'}
             />
             <Button
-              type='button'
+              type="button"
               className={`normalButton ${isDifficulty === 'NORMAL' ? 'isActive' : ''}`}
               onClick={() => setIsDifficulty('NORMAL')}
               children={'NORMAL'}
@@ -73,7 +73,7 @@ const EditMainQuestQuest = () => {
               color={'white'}
             />
             <Button
-              type='button'
+              type="button"
               className={`hardButton ${isDifficulty === 'HARD' ? 'isActive' : ''}`}
               onClick={() => setIsDifficulty('HARD')}
               children={'HARD'}
@@ -81,8 +81,7 @@ const EditMainQuestQuest = () => {
               color={'white'}
             />
           </QuestButtonContainer>
-          <div className="plusContainer">
-          </div>
+          <div className="plusContainer"></div>
           <InnerQuests>
             {content.sideQuests &&
               content.sideQuests.map((sideQuest: SideContent, index: number) => (
@@ -142,7 +141,7 @@ const EditMainQuestQuest = () => {
               color={'black'}
             />
             <Button
-              type='button'
+              type="button"
               className="closeButton"
               children={'삭제'}
               size={'medium'}
@@ -151,12 +150,12 @@ const EditMainQuestQuest = () => {
             />
           </div>
         </form>
-      </EditMainQuestQuestStyle>
+      </EditMainQuestStyle>
     </>
   );
 };
 
-const EditMainQuestQuestStyle = styled.div`
+const EditMainQuestStyle = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -35,7 +35,7 @@ const Login = () => {
       <LoginStyle>
         <LocalLogin>
           <LoginHeader>
-            <Title text="로그인" size="large" />
+            <Title text="로그인" size="large" color="blue" />
           </LoginHeader>
           <form onSubmit={handleSubmit(onSubmit)}>
             <fieldset>

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -17,7 +17,7 @@ import { getUserInfo } from '@/api/users.api';
 import Title from '@/components/common/Title';
 
 const Main = () => {
-  const { quest, isSubLoading } = useSubQuest();
+  const { subQuests, isSubLoading } = useSubQuest();
   const { mainQuests, isMainQuestsLoading, date } = useMainQuest();
   const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
 
@@ -67,8 +67,8 @@ const Main = () => {
           <CreateQuestButton modalName="subQuest" />
         </div>
         <div>
-          {quest?.length ? (
-            quest.map((content) => <SubBox key={content.id} content={content} />)
+          {subQuests?.length ? (
+            subQuests.map((content) => <SubBox key={content.id} content={content} />)
           ) : isSubLoading ? (
             <Loading />
           ) : (

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -18,7 +18,7 @@ import Title from '@/components/common/Title';
 
 const Main = () => {
   const { quest, isSubLoading } = useSubQuest();
-  const { mainQuest, isMainLoading, date } = useMainQuest();
+  const { mainQuests, isMainQuestsLoading, date } = useMainQuest();
   const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
 
   const { data: userInfoData, refetch } = useQuery<UserInfo>({
@@ -44,8 +44,8 @@ const Main = () => {
           <CreateQuestButton pageUrl="/createquest" />
         </div>
         <div>
-          {mainQuest?.length ? (
-            mainQuest?.map((content) => (
+          {mainQuests?.length ? (
+            mainQuests?.map((content) => (
               <MainBox
                 key={content.id}
                 content={content}
@@ -53,7 +53,7 @@ const Main = () => {
                 refetchMainBoxData={refetch}
               />
             ))
-          ) : isMainLoading ? (
+          ) : isMainQuestsLoading ? (
             <Loading />
           ) : (
             <p>등록된 메인 퀘스트가 없습니다</p>

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -14,6 +14,7 @@ import { UserInfo } from '@/models/userInfo.model';
 import { useQuery } from '@tanstack/react-query';
 import { USER } from '@/constant/queryKey';
 import { getUserInfo } from '@/api/users.api';
+import Title from '@/components/common/Title';
 
 const Main = () => {
   const { quest, isSubLoading } = useSubQuest();
@@ -39,12 +40,19 @@ const Main = () => {
       <section className="questSection">
         <div className="questTitle">
           <BiNotepad />
-          <h2>Main Quest</h2>
+          <Title text="Main Quest" size="small" color="black" />
           <CreateQuestButton pageUrl="/createquest" />
         </div>
         <div>
           {mainQuest?.length ? (
-            mainQuest?.map((content) => <MainBox key={content.id} content={content} date={date} refetchMainBoxData={refetch} />)
+            mainQuest?.map((content) => (
+              <MainBox
+                key={content.id}
+                content={content}
+                date={date}
+                refetchMainBoxData={refetch}
+              />
+            ))
           ) : isMainLoading ? (
             <Loading />
           ) : (
@@ -55,7 +63,7 @@ const Main = () => {
       <section className="questSection">
         <div className="questTitle">
           <BiNotepad />
-          <h2>Sub Quest</h2>
+          <Title text="Sub Quest" size="small" color="black" />
           <CreateQuestButton modalName="subQuest" />
         </div>
         <div>

--- a/client/src/pages/SignUp.tsx
+++ b/client/src/pages/SignUp.tsx
@@ -35,7 +35,7 @@ const SignUp = () => {
     <>
       <Header title="InGame" />
       <SignUpStyle>
-        <Title text="회원가입" size="large" />
+        <Title text="회원가입" size="large" color="blue" />
         <form onSubmit={handleSubmit(onSubmit)}>
           <fieldset>
             <div className="sendEmail">

--- a/client/src/utils/formatter.ts
+++ b/client/src/utils/formatter.ts
@@ -1,5 +1,5 @@
 export const formattedDate = (calendar: Date) =>
   calendar
     .toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' })
-    .replace(/\./g, '')
-    .replace(/ /g, '');
+    .replace(/\. /g, '-')
+    .slice(0, -1);


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

#### 메인 퀘스트 삭제 후, 메인 페이지로 이동 시 404 오류 해결
- React Query의 캐시가 비동기로 업데이트되어 발생한 문제
- async/await을 사용하여 해결
#### 날짜 입력할 때, 타입 불일치 문제 해결
- input 태그의 타입을 date로 설정했는데, string형태의 데이터를 보내서 발생한 문제
- 타입 일치시켜 해결
#### 메인 퀘스트의 상태와 상관없이 사이드 퀘스트 토글 열 수 있도록 수정
- 기존에는 메인 퀘스트를 완료시키면, 사이드 퀘스트를 보기 위한 토글을 열 수 없었음
- 퀘스트 완료 상태일 시, return하던 코드 삭제
#### 메인 퀘스트 완료 시 종속된 사이드 퀘스트 변경할 수 없도록 수정
- 기존에는 메인 퀘스트를 성공한 후, 종속된 사이드 퀘스트를 변경할 수 있었음
- 이 부분 변경할 수 없도록 수정
### 💡 이슈를 처리하면서 추가된 코드가 있어요.

#### 메인 퀘스트 삭제 후, 메인 페이지로 이동 시 404 오류 해결
- 성공 시, 비동기로 메인 퀘스트를 무효화하여 가져오는 코드를 순차적으로 동작하도록 async/await 추가 
```ts
// useMainQuest.ts
  const deleteMainQuestsMutation = useMutation({
    mutationFn: (id: number) => deleteMainQuest(id),
    onSuccess: async (_, deletedId) => {
      queryClient.removeQueries({
        queryKey: [...QUEST.GET_MAINQUEST, deletedId],
        exact: true,
      });
      await queryClient.invalidateQueries({
        queryKey: [...QUEST.GET_MAINQUEST, date],
      });
      navigate('/');
    },
    onError(err) {
      navigate('/error');
    },
  });
```
#### 날짜 입력할 때, 타입 불일치 문제 해결
```ts
// formatter.ts

export const formattedDate = (calendar: Date) =>
  calendar
    .toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' })
    .replace(/\. /g, '-')
    .slice(0, -1);

```

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
