### PR TITLE
[FE] 랭킹 조회 오류 수정

### DIFF
--- a/client/src/api/ranking.api.ts
+++ b/client/src/api/ranking.api.ts
@@ -2,12 +2,11 @@ import { API_END_POINT } from '@/constant/api';
 import { Pagination, RankingItem } from '@/models/ranking.model';
 import { httpClient } from '@/utils/axios';
 
-interface GetRankingParams { 
+interface GetRankingParams {
   totalPage: number;
 }
 export interface RankingResponse {
-  ranking: any;
-  data: RankingItem[];
+  rankings: RankingItem[];
   pagination: Pagination;
 }
 

--- a/client/src/api/ranking.api.ts
+++ b/client/src/api/ranking.api.ts
@@ -1,13 +1,9 @@
 import { API_END_POINT } from '@/constant/api';
-import { Pagination, RankingItem } from '@/models/ranking.model';
+import { RankingResponse } from '@/models/ranking.model';
 import { httpClient } from '@/utils/axios';
 
 interface GetRankingParams {
   totalPage: number;
-}
-export interface RankingResponse {
-  rankings: RankingItem[];
-  pagination: Pagination;
 }
 
 export const getRanking = async ({ totalPage }: GetRankingParams): Promise<RankingResponse> => {

--- a/client/src/components/ranking/RankingCardList.tsx
+++ b/client/src/components/ranking/RankingCardList.tsx
@@ -2,11 +2,6 @@ import styled from 'styled-components';
 import RankingCard from './RankingCard';
 import { useRank } from '@/hooks/useRank';
 import { useEffect, useRef } from 'react';
-import { RankingItem } from '@/models/ranking.model';
-
-interface RankingCardProps {
-  item: RankingItem;
-}
 
 const RankingCardList = () => {
   const { rankingData, fetchNextPage, hasNextPage } = useRank();
@@ -22,8 +17,8 @@ const RankingCardList = () => {
   useEffect(() => {
     const options = {
       root: null,
-      rootMargin: "0px",
-      threshold: 1.0
+      rootMargin: '0px',
+      threshold: 1.0,
     };
     const observer = new IntersectionObserver(handleObserver, options);
     if (loader.current) {
@@ -33,22 +28,25 @@ const RankingCardList = () => {
       if (loader.current) {
         observer.unobserve(loader.current);
       }
-    }
+    };
   }, [fetchNextPage, hasNextPage]);
 
   return (
     <>
       <RankingCardListStyle>
-      {rankingData && rankingData.flatMap((response) => response.ranking).map((rankingItem) => (
-        <RankingCard
-          id={rankingItem.id}
-          nickname={rankingItem.nickname}
-          point={rankingItem.point}
-          rank={rankingItem.rank}
-          level={rankingItem.level}
-          key={rankingItem.id}
-        />
-      ))}
+        {rankingData &&
+          rankingData
+            .flatMap((response) => response.rankings)
+            .map((rankingItem) => (
+              <RankingCard
+                id={rankingItem.id}
+                nickname={rankingItem.nickname}
+                point={rankingItem.point}
+                rank={rankingItem.rank}
+                level={rankingItem.level}
+                key={rankingItem.id}
+              />
+            ))}
         <div ref={loader} />
       </RankingCardListStyle>
     </>

--- a/client/src/hooks/useRank.ts
+++ b/client/src/hooks/useRank.ts
@@ -1,15 +1,13 @@
-import { RankingResponse, getRanking } from '@/api/ranking.api';
+import { getRanking } from '@/api/ranking.api';
 import { RANK } from '@/constant/queryKey';
+import { RankingResponse } from '@/models/ranking.model';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
 export const useRank = () => {
-  const {
-    data,
-    isLoading,
-    isError,
-    fetchNextPage,
-    hasNextPage,
-  } = useInfiniteQuery<RankingResponse, unknown>({
+  const { data, isLoading, isError, fetchNextPage, hasNextPage } = useInfiniteQuery<
+    RankingResponse,
+    unknown
+  >({
     queryKey: RANK.GET_RANKING,
     queryFn: ({ pageParam = 1 }) => getRanking({ totalPage: Number(pageParam) }),
     getNextPageParam: (lastPage) => {
@@ -18,7 +16,7 @@ export const useRank = () => {
     },
     initialPageParam: 1,
   });
-  
+
   const rankingData = data ? data.pages.flatMap((page) => page) : [];
 
   return { rankingData, isLoading, isError, fetchNextPage, hasNextPage };

--- a/client/src/models/ranking.model.ts
+++ b/client/src/models/ranking.model.ts
@@ -12,6 +12,6 @@ export interface Pagination {
 }
 
 export interface RankingResponse {
-  ranking: RankingItem[];
+  rankings: RankingItem[];
   pagination: Pagination;
 }


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

#### 반환받은 데이터 일치시키기

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

#### 반환받은 데이터 일치시키기
```ts
// RankingCardList.tsx

const RankingCardList = () => {
...
  return (
    <>
      <RankingCardListStyle>
        {rankingData &&
          rankingData
            .flatMap((response) => response.rankings)
            .map((rankingItem) => (
              <RankingCard
                id={rankingItem.id}
                nickname={rankingItem.nickname}
                point={rankingItem.point}
                rank={rankingItem.rank}
                level={rankingItem.level}
                key={rankingItem.id}
              />
            ))}
        <div ref={loader} />
      </RankingCardListStyle>
    </>
  );
};
```

#### 타입 수정
```ts
export interface RankingItem {
  id: number;
  nickname: string;
  point: number;
  rank: number;
  level: number;
}

export interface Pagination {
  totalPage: number;
  nextPage: number;
}

export interface RankingResponse {
  rankings: RankingItem[];
  pagination: Pagination;
}

```
### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
