### PR TITLE
[BE] 랭킹 데이터 반환되지 않는 오류 해결

### DIFF
--- a/server/src/common/dto/ranking/ranking.dto.ts
+++ b/server/src/common/dto/ranking/ranking.dto.ts
@@ -1,17 +1,18 @@
-import { UserInfoWithRankDto } from '../user-info';
+import { Expose } from 'class-transformer';
 
 export class RankingDto {
+  @Expose()
   readonly id: number;
-  readonly nickname: string;
-  readonly point: number;
-  readonly rank: number;
-  readonly level: number;
 
-  constructor(userInfo: UserInfoWithRankDto, level: number) {
-    this.id = userInfo.id;
-    this.nickname = userInfo.nickname;
-    this.point = userInfo.point;
-    this.rank = userInfo.rank;
-    this.level = level;
-  }
+  @Expose()
+  readonly nickname: string;
+
+  @Expose()
+  readonly point: number;
+
+  @Expose()
+  readonly rank: number;
+
+  @Expose()
+  readonly level: number;
 }

--- a/server/src/common/dto/user-info/user-info-with-rank.dto.ts
+++ b/server/src/common/dto/user-info/user-info-with-rank.dto.ts
@@ -1,31 +1,15 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
 
 export class UserInfoWithRankDto {
-  @ApiProperty({
-    example: 1,
-    description: 'id',
-    required: true,
-  })
-  id: number;
+  @Expose()
+  readonly id: number;
 
-  @ApiProperty({
-    example: 'test',
-    description: '닉네임',
-    required: true,
-  })
-  nickname: string;
+  @Expose()
+  readonly nickname: string;
 
-  @ApiProperty({
-    example: 0,
-    description: '포인트 점수',
-    required: true,
-  })
-  point: number;
+  @Expose()
+  readonly point: number;
 
-  @ApiProperty({
-    example: 1,
-    description: '순위',
-    required: true,
-  })
-  rank: number;
+  @Expose()
+  readonly rank: number;
 }

--- a/server/src/common/responses/pagination/pagination.response.ts
+++ b/server/src/common/responses/pagination/pagination.response.ts
@@ -1,6 +1,9 @@
+import { Expose } from 'class-transformer';
+
 export class PaginationResponse {
-  constructor(
-    readonly totalPage: number,
-    readonly nextPage: number
-  ) {}
+  @Expose()
+  readonly totalPage: number;
+
+  @Expose()
+  readonly nextPage: number;
 }

--- a/server/src/common/responses/ranking/ranking.response.ts
+++ b/server/src/common/responses/ranking/ranking.response.ts
@@ -1,9 +1,11 @@
 import { RankingDto } from '@common/dto/ranking';
 import { PaginationResponse } from '../pagination';
+import { Expose } from 'class-transformer';
 
 export class RankingResponse {
-  constructor(
-    readonly rankings: RankingDto[],
-    readonly pagination: PaginationResponse
-  ) {}
+  @Expose()
+  readonly rankings: RankingDto[];
+
+  @Expose()
+  readonly pagination: PaginationResponse;
 }

--- a/server/src/modules/ranking/ranking.controller.ts
+++ b/server/src/modules/ranking/ranking.controller.ts
@@ -1,13 +1,4 @@
-import {
-  Controller,
-  Get,
-  HttpCode,
-  HttpStatus,
-  Inject,
-  Query,
-  UsePipes,
-  ValidationPipe,
-} from '@nestjs/common';
+import { Controller, Get, HttpCode, HttpStatus, Inject, Query } from '@nestjs/common';
 import {
   ApiInternalServerErrorResponse,
   ApiOkResponse,
@@ -28,8 +19,7 @@ export class RankingController {
   @ApiOkResponse({ type: RankingResponse, isArray: true })
   @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
   @HttpCode(HttpStatus.OK)
-  @UsePipes(new ValidationPipe({ transform: true }))
-  findRankingByPage(@Query() paginationRequest: PaginationRequest): Promise<RankingResponse> {
-    return this.rankingService.getRankingByPage(paginationRequest);
+  findRankingByPage(@Query() request: PaginationRequest): Promise<RankingResponse> {
+    return this.rankingService.getRankingByPage(request);
   }
 }


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

#### 랭킹 데이터 반환되지 않는 오류 해결
- 랭킹 데이터 반환을 위한 객체가 생성되지만, 데이터가 정상적으로 반환되지 않는 오류 발생
- main.ts에서 excludeExtraneousValues: true 속성을 추가하여 `@Expose()` 데코레이터가 명시적으로 지정된 속성만 직렬화되어 응답에 포함되도록 설정
- 그러나, 기존 코드는 `@Expose()` 데코레이터가 명시적으로 지정되지 않아 발생한 오류
- `@Expose()` 데코레이터를 명시적으로 지정해줌으로써, 오류 해결

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
