### PR TITLE
[FE] 메인 페이지 수정

### DIFF
--- a/client/src/components/UserProfile/ProgressBar.tsx
+++ b/client/src/components/UserProfile/ProgressBar.tsx
@@ -2,16 +2,14 @@ import styled from 'styled-components';
 import { Progress } from 'antd';
 
 interface ProgressBarProps {
-  point: number;
+  levelProgress: number;
 }
 
-const calcProgressPercent = (point: number) => Math.floor(((point % 1024) / 1024) * 100);
-
-const ProgressBar = ({ point }: ProgressBarProps) => {
+const ProgressBar = ({ levelProgress }: ProgressBarProps) => {
   return (
     <ProgressBarStyle>
       <Progress
-        percent={calcProgressPercent(point)}
+        percent={levelProgress}
         size={['100%', 25]}
         strokeColor="#0ACF83"
         trailColor="#E2F8F1"

--- a/client/src/components/UserProfile/UserProfile.tsx
+++ b/client/src/components/UserProfile/UserProfile.tsx
@@ -10,7 +10,6 @@ interface UserProfileProps {
 }
 
 const UserProfile = ({ userInfo }: UserProfileProps) => {
-
   return (
     <UserProfileStyle>
       {userInfo && (
@@ -24,7 +23,7 @@ const UserProfile = ({ userInfo }: UserProfileProps) => {
               <EditProfileButton nickname={userInfo.nickname} intro={userInfo.intro} />
             </div>
             <div className="progress__bar">
-              <ProgressBar point={userInfo.point} />
+              <ProgressBar levelProgress={userInfo.levelProgress} />
             </div>
             <span className="introduction">{userInfo.intro}</span>
           </UserDetailInfoStyle>

--- a/client/src/components/quests/MainBox.tsx
+++ b/client/src/components/quests/MainBox.tsx
@@ -13,10 +13,10 @@ import { useSideQuest } from '@/hooks/useSideQuest';
 export interface MainBoxProps {
   content: MainQuest;
   date: string;
-  refetchMainBoxData: () => void;
+  refetchUserInfo: () => void;
 }
 
-const MainBox = ({ content, date, refetchMainBoxData }: MainBoxProps) => {
+const MainBox = ({ content, date, refetchUserInfo }: MainBoxProps) => {
   const [sideQuests, setSideQuests] = useState(content.sideQuests);
   const [isAccordion, setIsAccordion] = useState(false);
   const { patchSideMutation } = useSideQuest();
@@ -35,7 +35,7 @@ const MainBox = ({ content, date, refetchMainBoxData }: MainBoxProps) => {
 
   const handleChangeStatus = () => {
     let message = '';
-    let newStatus = '';
+    let newStatus: QuestStatus;
     const completedSideQuests = sideQuests.filter(
       (sideQuest) => sideQuest.status === 'COMPLETED'
     ).length;
@@ -55,9 +55,8 @@ const MainBox = ({ content, date, refetchMainBoxData }: MainBoxProps) => {
     }
 
     showConfirm(message, () => {
-      content.status = newStatus as QuestStatus;
-      modifyMainQuestStatus({ id: content.id, status: content.status }).then(() => {
-        refetchMainBoxData();
+      modifyMainQuestStatus({ id: content.id, status: newStatus }).then(() => {
+        refetchUserInfo();
       });
     });
   };

--- a/client/src/components/quests/SubBox.tsx
+++ b/client/src/components/quests/SubBox.tsx
@@ -8,29 +8,32 @@ import { useState } from 'react';
 
 interface SubBoxProps {
   content: SubQuest;
+  refetchUserInfo: () => void;
 }
 
-const SubBox = ({ content }: SubBoxProps) => {
-  const { modifySubQuestStatus, date } = useSubQuest();
+const SubBox = ({ content, refetchUserInfo }: SubBoxProps) => {
+  const { modifySubQuestStatus } = useSubQuest();
   const { showConfirm, showAlert } = useMessage();
   const [open, setOpen] = useState(false);
 
-  const handleChangeStatue = () => {
+  const handleChangeStatus = () => {
     let message = '';
-    let status = content.status;
+    let newStatus: QuestStatus;
     if (content.status === 'ON_PROGRESS') {
       message = '퀘스트를 완료하시겠습니까?';
-      status = 'COMPLETED';
+      newStatus = 'COMPLETED';
     } else if (content.status === 'COMPLETED') {
       message = '퀘스트를 진행중으로 변경하시겠습니까?';
-      status = 'ON_PROGRESS';
+      newStatus = 'ON_PROGRESS';
     } else {
       showAlert('실패한 퀘스트를 수정할 수 없습니다');
       return;
     }
 
     showConfirm(message, () => {
-      modifySubQuestStatus({ id: content.id, status: status });
+      modifySubQuestStatus({ id: content.id, status: newStatus }).then(() => {
+        refetchUserInfo();
+      });
     });
   };
 
@@ -41,7 +44,7 @@ const SubBox = ({ content }: SubBoxProps) => {
 
   return (
     <SubBoxStyle $status={content.status}>
-      <div onClick={handleChangeStatue} className="clickDiv">
+      <div onClick={handleChangeStatus} className="clickDiv">
         <h2>{content.title}</h2>
         <button onClick={handleEdit} className="EditBtn">
           <BsThreeDots />

--- a/client/src/hooks/useMainQuest.ts
+++ b/client/src/hooks/useMainQuest.ts
@@ -77,7 +77,7 @@ export const useMainQuest = (questId?: number) => {
     mutationFn: (data: ModifyQuestStatusProps) => modiQuestStatus(data),
     onSuccess() {
       queryClient.invalidateQueries({
-        queryKey: [...QUEST.GET_MAINQUEST, params.get(QUERYSTRING.DATE)],
+        queryKey: [...QUEST.GET_MAINQUEST, date],
       });
     },
     onError(err) {},

--- a/client/src/hooks/useSubQuest.ts
+++ b/client/src/hooks/useSubQuest.ts
@@ -43,7 +43,7 @@ export const useSubQuest = () => {
   });
 
   const modifySubQuestStatus = (data: ModifyQuestStatusProps) => {
-    modifyQuestStatusMutation.mutate(data);
+    return modifyQuestStatusMutation.mutateAsync(data);
   };
 
   const modifyQuestStatusMutation = useMutation({

--- a/client/src/hooks/useUserInfo.ts
+++ b/client/src/hooks/useUserInfo.ts
@@ -1,0 +1,13 @@
+import { getUserInfo } from '@/api/users.api';
+import { USER } from '@/constant/queryKey';
+import { UserInfo } from '@/models/userInfo.model';
+import { useQuery } from '@tanstack/react-query';
+
+export const useUserInfo = () => {
+  const { data: userInfo, refetch } = useQuery<UserInfo>({
+    queryKey: [...USER.GET_USERINFO],
+    queryFn: () => getUserInfo(),
+  });
+
+  return { userInfo, refetch };
+};

--- a/client/src/mocks/data/mockUser.ts
+++ b/client/src/mocks/data/mockUser.ts
@@ -8,4 +8,5 @@ export const mockUserInfo: UserInfo = {
   profilePhoto: 'lion',
   point: 3000,
   level: 5,
+  levelProgress: 50,
 };

--- a/client/src/models/userInfo.model.ts
+++ b/client/src/models/userInfo.model.ts
@@ -6,4 +6,5 @@ export interface UserInfo {
   profilePhoto: string;
   point: number;
   level: number;
+  levelProgress: number;
 }

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -9,37 +9,19 @@ import MainBox from '@/components/quests/MainBox';
 import { BiNotepad } from 'react-icons/bi';
 import { useMainQuest } from '@/hooks/useMainQuest';
 import CreateQuestButton from '@/components/CreateQuestButton';
-import { useEffect, useState } from 'react';
-import { UserInfo } from '@/models/userInfo.model';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { USER } from '@/constant/queryKey';
-import { getUserInfo } from '@/api/users.api';
 import Title from '@/components/common/Title';
+import { useUserInfo } from '@/hooks/useUserInfo';
 
 const Main = () => {
   const { subQuests, isSubLoading } = useSubQuest();
   const { mainQuests, isMainQuestsLoading, date } = useMainQuest();
-  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
-
-  console.log('subQuests:', subQuests);
-  console.log('mainQuests: ', mainQuests);
-
-  const { data: userInfoData, refetch } = useQuery<UserInfo>({
-    queryKey: [...USER.GET_USERINFO],
-    queryFn: () => getUserInfo(),
-  });
-
-  useEffect(() => {
-    if (userInfoData) {
-      setUserInfo(userInfoData);
-    }
-  }, [userInfoData]);
+  const { userInfo, refetch } = useUserInfo();
 
   return (
     <MainStyle>
       <Dropdown />
       <WeekCalendar />
-      <UserProfile userInfo={userInfo} />
+      <UserProfile userInfo={userInfo!} />
       <section className="questSection">
         <div className="questTitle">
           <BiNotepad />

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -17,6 +17,8 @@ const Main = () => {
   const { mainQuests, isMainQuestsLoading, date } = useMainQuest();
   const { userInfo, refetch } = useUserInfo();
 
+  console.log(userInfo);
+
   return (
     <MainStyle>
       <Dropdown />
@@ -31,12 +33,7 @@ const Main = () => {
         <div>
           {mainQuests?.length ? (
             mainQuests?.map((content) => (
-              <MainBox
-                key={content.id}
-                content={content}
-                date={date}
-                refetchMainBoxData={refetch}
-              />
+              <MainBox key={content.id} content={content} date={date} refetchUserInfo={refetch} />
             ))
           ) : isMainQuestsLoading ? (
             <Loading />
@@ -53,7 +50,9 @@ const Main = () => {
         </div>
         <div>
           {subQuests?.length ? (
-            subQuests.map((content) => <SubBox key={content.id} content={content} />)
+            subQuests.map((content) => (
+              <SubBox key={content.id} content={content} refetchUserInfo={refetch} />
+            ))
           ) : isSubLoading ? (
             <Loading />
           ) : (


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

#### 퀘스트 완료 시, progressBar 변경되도록 수정
- 기존에는 레벨업에 필요한 포인트가 `1024`라고 가정하여 계산 함수를 구현
- 서버의 레벨 시스템을 적용하여 진척도를 계산하도록 수정
- 레벨을 이미 서버에서 계산하여 보내고 있고, 연산이 필요한 작업은 서버에서 담당하는게 맞다고 판단
- 서버에서 연산하여 클라이언트에게 보내주도록 수정

#### 서브 퀘스트 상태 변경 시, 변경된 유저 정보가 메인 페이지에 반영되도록 수정
- `mutateAsync`를 사용하여 퀘스트의 상태 변경 시, 유저 정보를 다시 가져오도록 수정

#### 메인 퀘스트 상태 변경 시, 캐싱된 메인 퀘스트 정보가 무효화되지 않는 에러 수정
- 쿼리키가 다른 변수로 설정되어 발생한 문제
- 같은 값으로 수정하니, 정상 작동함
### 💡 이슈를 처리하면서 추가된 코드가 있어요.

#### 퀘스트 완료 시, progressBar 변경되도록 수정
```ts
// ProgressBar.tsx
interface ProgressBarProps {
  levelProgress: number;
}

const ProgressBar = ({ levelProgress }: ProgressBarProps) => {
  return (
    <ProgressBarStyle>
      <Progress
        percent={levelProgress}
        size={['100%', 25]}
        strokeColor="#0ACF83"
        trailColor="#E2F8F1"
      />
    </ProgressBarStyle>
  );
};

const ProgressBarStyle = styled.div`
  width: 100%;
`;

export default ProgressBar;
```

#### 서브 퀘스트 상태 변경 시, 변경된 유저 정보가 메인 페이지에 반영되도록 수정
```ts
// useSubQuest.ts
...
  const modifySubQuestStatus = (data: ModifyQuestStatusProps) => {
    return modifyQuestStatusMutation.mutateAsync(data);
  };
  
// SubBox.tsx

  const handleChangeStatus = () => {
  ...
      showConfirm(message, () => {
      // 퀘스트 상태가 변경된 후, 유저 정보를 다시 가져오도록 수정
      modifySubQuestStatus({ id: content.id, status: newStatus }).then(() => {
        refetchUserInfo();
      });
    });
```
#### 메인 퀘스트 상태 변경 시, 캐싱된 메인 퀘스트 정보가 무효화되지 않는 에러 수정
- `params.get(QUERYSTRING.DATE)`와 `date`는 값은 같지만, 다른 변수임으로 무효화되지 않던 것
- `date`로 통일하여 사용함으로써 에러 해결
```ts
// useMainQuest.ts

...
  const modifyMainQuestStatus = (data: ModifyQuestStatusProps) => {
    return modifyQuestStatusMutation.mutateAsync(data);
  };

  const modifyQuestStatusMutation = useMutation({
    mutationFn: (data: ModifyQuestStatusProps) => modiQuestStatus(data),
    onSuccess() {
      queryClient.invalidateQueries({
        queryKey: [...QUEST.GET_MAINQUEST, date], // 기존: params.get(QUERYSTRING.DATE) 
      });
    },
    onError(err) {},
  });
```

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
