### PR TITLE
[BE] 다음 레벨까지의 진척도 계산을 서버에서 진행하도록 수정

### DIFF
--- a/server/src/common/responses/user/user.response.ts
+++ b/server/src/common/responses/user/user.response.ts
@@ -25,4 +25,7 @@ export class UserResponse {
 
   @Expose()
   readonly level: number;
+
+  @Expose()
+  readonly levelProgress: number;
 }

--- a/server/src/core/level-calculator/level-calculator.service.ts
+++ b/server/src/core/level-calculator/level-calculator.service.ts
@@ -14,21 +14,37 @@ export class LevelCalculatorService {
     for (let level = 1; level <= maxLevel; level++) {
       this.levelInfoList.push({ level, minPoint, maxPoint });
       minPoint = maxPoint + 1;
-      maxPoint += Math.round(initialExp * Math.pow(1 + increaseRate, level - 1));
+      maxPoint += Math.round(initialExp * Math.pow(1 + increaseRate, level));
     }
   }
 
   public findLevel(point: number): LevelInfo {
-    if (point < this.levelInfoList[0].minPoint) return this.levelInfoList[0];
-
     const maxLevelIndex = this.levelInfoList.length - 1;
+
     if (point > this.levelInfoList[maxLevelIndex].maxPoint) {
       return this.levelInfoList[maxLevelIndex];
     }
 
-    const levelInfo = this.levelInfoList.find(
-      (levelInfo) => point >= levelInfo.minPoint && point <= levelInfo.maxPoint
+    return (
+      this.levelInfoList.find(
+        (levelInfo) => point >= levelInfo.minPoint && point <= levelInfo.maxPoint
+      ) || this.levelInfoList[0]
     );
-    return levelInfo;
+  }
+
+  public calculateLevelProgress(point: number): number {
+    const levelInfo = this.findLevel(point);
+
+    if (!levelInfo) {
+      return 0;
+    }
+
+    const { minPoint, maxPoint } = levelInfo;
+    const levelPoint = maxPoint - minPoint + 1;
+    const currentLevePoint = point - minPoint;
+
+    const progress = Math.floor(100 * (currentLevePoint / levelPoint));
+
+    return Math.min(progress, 99);
   }
 }

--- a/server/src/modules/point/point.controller.ts
+++ b/server/src/modules/point/point.controller.ts
@@ -1,14 +1,4 @@
-import {
-  Body,
-  Controller,
-  HttpCode,
-  HttpStatus,
-  Inject,
-  Patch,
-  UseGuards,
-  UsePipes,
-  ValidationPipe,
-} from '@nestjs/common';
+import { Body, Controller, HttpCode, HttpStatus, Inject, Patch, UseGuards } from '@nestjs/common';
 import { AccessTokenPayload } from '../auth/auth.interface';
 import { CurrentUser } from 'src/core/decorators/current-user.decorator';
 import {

--- a/server/src/modules/user/user.service.ts
+++ b/server/src/modules/user/user.service.ts
@@ -86,8 +86,9 @@ export class UserService implements IUserService {
   async findUserById(id: number): Promise<UserResponse> {
     const user = await this.findById(id);
     const level = this.levelCalculatorService.findLevel(user.userInfo.point).level;
+    const levelProgress = this.levelCalculatorService.calculateLevelProgress(user.userInfo.point);
 
-    return plainToInstance(UserResponse, { ...user, level });
+    return plainToInstance(UserResponse, { ...user, level, levelProgress });
   }
 
   async updateUserInfoById(userId: number, request: UpdateUserRequest): Promise<void> {


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

#### 다음 레벨까지의 진척도 계산을 서버에서 진행하도록 수정
- 이미 레벨은 서버에서 계산하여 클라이언트에게 전달
- 진척도를 계산하기 위해 필요한 값들은 서버에만 존재
- 따라서, 서버에서 연산하여 클라이언트에게 보내주는 것이 옳다고 판단되어 수정

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

#### 다음 레벨까지의 진척도 계산을 서버에서 진행하도록 수정
```ts
// level-calculator.service.ts

export class LevelCalculatorService {
...
  public calculateLevelProgress(point: number): number {
    const levelInfo = this.findLevel(point);

    if (!levelInfo) {
      return 0;
    }

    const { minPoint, maxPoint } = levelInfo;
    const levelPoint = maxPoint - minPoint + 1;
    const currentLevePoint = point - minPoint;

    const progress = Math.floor(100 * (currentLevePoint / levelPoint));

    return Math.min(progress, 99);
  }
  
// user.service.ts

@Injectable()
export class UserService implements IUserService {
  constructor(
    private readonly configService: ConfigService,
    @Inject(USER_REPOSITORY_KEY) private userRepository: IUserRepository,
    @Inject(USER_INFO_REPOSITORY_KEY) private userInfoRepository: IUserInfoRepository,
    @Inject(PROFILE_PHOTO_REPOSITORY_KEY) private profilePhotoRepository: IProfilePhotoRepository,
    private readonly levelCalculatorService: LevelCalculatorService
  ) {}
...
  async findUserById(id: number): Promise<UserResponse> {
    const user = await this.findById(id);
    const level = this.levelCalculatorService.findLevel(user.userInfo.point).level;
    const levelProgress = this.levelCalculatorService.calculateLevelProgress(user.userInfo.point);

    return plainToInstance(UserResponse, { ...user, level, levelProgress });
  }
...
}
```
### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
