### PR TITLE
[BE] 시작 날짜와 종료 날짜 반환 값의 형태 변경

### DIFF
--- a/server/src/common/responses/quest/main-quest.response.ts
+++ b/server/src/common/responses/quest/main-quest.response.ts
@@ -1,6 +1,5 @@
-import { Difficulty, Hidden, Status } from '@common/types/quest/quest.type';
+import { Difficulty, Hidden, Mode, Status } from '@common/types/quest/quest.type';
 import { Expose, Type } from 'class-transformer';
-import { Mode } from 'fs';
 import { SideQuestResponse } from './side-quest.response';
 
 export class MainQuestResponse {
@@ -27,10 +26,10 @@ export class MainQuestResponse {
   sideQuests: SideQuestResponse[];
 
   @Expose()
-  startDate: Date;
+  startDate: string;
 
   @Expose()
-  endDate: Date;
+  endDate: string;
 
   @Expose()
   createdAt: Date;

--- a/server/src/common/utils/date.util.ts
+++ b/server/src/common/utils/date.util.ts
@@ -26,7 +26,7 @@ export const toEndUTC = (dateString: string): Date => {
 };
 
 export const toDateString = (date: Date): string => {
-  return dayjs(date).tz(DEFAULT_TIMEZONE).format('YYYYMMDD');
+  return dayjs(date).tz(DEFAULT_TIMEZONE).format('YYYY-MM-DD');
 };
 
 export const getExpiredDate = (): Date => {


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

#### 시작 날짜와 종료 날짜 반환 값의 형태 변경
- 반환된 값이 그대로 클라이언트의 input 박스에 들어감
- 그러나, input 박스의 타입은 date인데, 반환 값이 '20240910' 형태라 에러 발생
- '2024-09-10' 형태로 반환하도록 수정


### 💡 이슈를 처리하면서 추가된 코드가 있어요.

#### 시작 날짜와 종료 날짜 반환 값의 형태 변경
```ts
// date.util.ts
export const toDateString = (date: Date): string => {
  return dayjs(date).tz(DEFAULT_TIMEZONE).format('YYYY-MM-DD');
};
```

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
