### PR TITLE
[BE] 메인 퀘스트 생성 및 수정 리팩토링

### DIFF
--- a/server/src/common/requests/quest/create-quest.request.ts
+++ b/server/src/common/requests/quest/create-quest.request.ts
@@ -17,11 +17,12 @@ export class CreateQuestRequest {
 
   @ApiProperty({
     enum: Difficulty,
-    example: 'normal',
+    example: 'NORMAL',
     description: '퀘스트 난이도',
     required: true,
   })
   @IsEnum(Difficulty)
+  @ValidateIf((quest) => quest.mode === Mode.Main)
   @IsNotEmpty()
   difficulty: Difficulty;
 

--- a/server/src/common/requests/quest/create-quest.request.ts
+++ b/server/src/common/requests/quest/create-quest.request.ts
@@ -19,7 +19,7 @@ export class CreateQuestRequest {
     enum: Difficulty,
     example: 'NORMAL',
     description: '퀘스트 난이도',
-    required: true,
+    required: false,
   })
   @IsEnum(Difficulty)
   @ValidateIf((quest) => quest.mode === Mode.Main)

--- a/server/src/common/requests/quest/update-main-quest.request.ts
+++ b/server/src/common/requests/quest/update-main-quest.request.ts
@@ -37,7 +37,7 @@ export class UpdateMainQuestRequest {
 
   @ApiProperty({
     type: [UpdateSideQuestRequest],
-    description: '사이드 퀘스트의 내용들',
+    description: '사이드 퀘스트의 내용들 (새로운 사이드 퀘스트는 id 없이 content만 포함)',
     required: false,
   })
   @IsNotEmpty()

--- a/server/src/common/requests/quest/update-side-quest.request.ts
+++ b/server/src/common/requests/quest/update-side-quest.request.ts
@@ -1,15 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsOptional, IsString } from 'class-validator';
 
 export class UpdateSideQuestRequest {
   @ApiProperty({
     example: 1,
-    description: '사이드 퀘스트 ID',
-    required: true,
+    description: '사이드 퀘스트 ID (새로운 사이드 퀘스트의 경우 없음)',
+    required: false,
   })
-  @IsNotEmpty()
   @IsNumber()
-  id: number;
+  @IsOptional()
+  id?: number;
 
   @ApiProperty({
     example: '사이드 퀘스트 1',


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

#### 퀘스트 생성 시, 메인 퀘스트만 difficulty 값 필수로 설정
- 서브 퀘스트 생성 시, difficulty 값은 DEFAULT로 고정
- 따라서, difficulty 값을 받을 필요 없음

#### 메인 퀘스트 수정 시, 새로운 사이드 퀘스트 추가할 수 있도록 수정
- 메인 퀘스트 수정 시, 새로운 사이드 퀘스트 추가할 수 있도록 수정

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

#### 퀘스트 생성 시, 메인 퀘스트만 difficulty 값 필수로 설정
```ts
// create-quest.request.ts

export class CreateQuestRequest {
...
  @ApiProperty({
    enum: Difficulty,
    example: 'NORMAL',
    description: '퀘스트 난이도',
    required: false,
  })
  @IsEnum(Difficulty)
  @ValidateIf((quest) => quest.mode === Mode.Main)
  @IsNotEmpty()
  difficulty: Difficulty;
...
}
```

#### 메인 퀘스트 수정 시, 새로운 사이드 퀘스트 추가할 수 있도록 수정
```ts
// side-quest.service.ts
...
  async updateSideQuests(
    questId: number,
    sideQuestRequests: UpdateSideQuestRequest[]
  ): Promise<void> {
    const sideQuests = await this.findSideQuests(questId);
    const deleteSideQuestIds = new Set(sideQuests.map((sideQuest) => sideQuest.id));

    for (const request of sideQuestRequests) {
      if (request.id) {
        const target = sideQuests.find((sideQuest) => sideQuest.id === request.id);
        if (target) {
          deleteSideQuestIds.delete(request.id);
          await target.updateContent(request.content);
          await this.sideQuestRepository.save(target);
        }
      } else {
        const newSideQuest = SideQuest.create(questId, request.content);
        await this.sideQuestRepository.save(newSideQuest);
      }
    }
...
```



### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
