### PR TITLE
[BE] Docker image build시 build폴더가 COPY되지 않는 오류 해결

### DIFF
--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,5 +1,4 @@
 .env
 node_modules
-build
 .vscode
 .gitignore

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,11 +1,18 @@
 FROM node:18
+
+ENV NODE_ENV production
+
 WORKDIR /usr/src/app
 
 RUN npm install -g serve
+
 COPY build ./build
 
 EXPOSE 3000
 
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN chmod u+x /usr/local/bin/docker-entrypoint.sh
-ENTRYPOINT ["docker-entrypoint.sh"]
+
+ENTRYPOINT ["docker-entrypoint.sh"] 
+
+


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.


#### Docker image build시 build폴더가 COPY되지 않는 오류 해결
- .dockerignore에서 build 삭제
- Dockerfile에서 NODE_ENV production 추가

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
