### PR TITLE
[FE/BE] refreshToken create와 update 메서드 병합 및 로그인 시, 로그인 페이지로 접근하면 메인페이지로 리다이렉트 하도록 수정

### DIFF
--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -10,6 +10,9 @@ import Header from '@/components/common/Header';
 import GoogleIcon from '@/assets/images/google-icon.png';
 import KakaoIcon from '@/assets/images/kakao-icon.png';
 import NaverIcon from '@/assets/images/naver-icon.png';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getToken } from '@/utils/tokenUtils';
 
 export interface LoginProps {
   email: string;
@@ -18,6 +21,7 @@ export interface LoginProps {
 
 const Login = () => {
   const { userLogin } = useAuth();
+  const navigate = useNavigate();
 
   const {
     register,
@@ -28,6 +32,12 @@ const Login = () => {
   const onSubmit = (data: LoginProps) => {
     userLogin(data);
   };
+
+  useEffect(() => {
+    if (getToken()) {
+      navigate(ROUTERS.MAIN);
+    }
+  }, [getToken()]);
 
   return (
     <>

--- a/client/src/utils/axios.ts
+++ b/client/src/utils/axios.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosRequestConfig, CreateAxiosDefaults } from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 import { getToken, removeToken, setToken } from './tokenUtils';
 import { SERVER_API_URL } from '../settings';
 import { logout, refreshToken } from '@/api/auth.api';

--- a/server/src/core/token/interfaces/token-service.interface.ts
+++ b/server/src/core/token/interfaces/token-service.interface.ts
@@ -1,14 +1,12 @@
 import { AccessTokenPayload, RefreshTokenPayload } from 'src/common/dto/token';
 import { AuthTokenResponse } from 'src/common/responses/token';
-import { RefreshToken } from 'src/entities/refresh-token/refresh-token.entity';
 
 export const TOKEN_SERVICE_KEY = 'tokenServiceKey';
 
 export interface ITokenService {
   createAccessToken(payload: AccessTokenPayload): Promise<string>;
-  createRefreshToken(userId: number): Promise<string>;
-  updateRefreshToken(userId: number, refreshToken: RefreshToken): Promise<string>;
+  upsertRefreshToken(userId: number): Promise<string>;
   deleteToken(refreshToken: string): Promise<void>;
-  refresh(refreshToken: string, payload: AccessTokenPayload): Promise<AuthTokenResponse>;
+  refresh(payload: AccessTokenPayload): Promise<AuthTokenResponse>;
   verifiedRefreshToken(refreshToken: string): Promise<RefreshTokenPayload>;
 }

--- a/server/src/entities/refresh-token/refresh-token-repository.interface.ts
+++ b/server/src/entities/refresh-token/refresh-token-repository.interface.ts
@@ -5,6 +5,6 @@ import { DeleteResult } from 'typeorm';
 export const REFRESH_TOKEN_REPOSITORY_KEY = 'refreshTokenRepositoryKey';
 
 export interface IRefreshTokenRepository extends IGenericRepository<RefreshToken> {
-  findByUserId(userId: number, token: string): Promise<RefreshToken | null>;
+  findByUserId(userId: number): Promise<RefreshToken | null>;
   deleteByToken(refreshToken: string): Promise<DeleteResult>;
 }

--- a/server/src/entities/refresh-token/refresh-token.repository.ts
+++ b/server/src/entities/refresh-token/refresh-token.repository.ts
@@ -11,9 +11,9 @@ export class RefreshTokenRepository
     return RefreshToken.name;
   }
 
-  findByUserId(userId: number, token: string): Promise<RefreshToken> {
+  findByUserId(userId: number): Promise<RefreshToken> {
     return this.getRepository().findOne({
-      where: { user: { id: userId }, token },
+      where: { user: { id: userId } },
       relations: ['user'],
     });
   }

--- a/server/src/modules/auth/auth.service.ts
+++ b/server/src/modules/auth/auth.service.ts
@@ -49,7 +49,7 @@ export class AuthService implements IAuthService {
 
   async login(payload: AccessTokenPayload): Promise<AuthTokenResponse> {
     const accessToken = await this.tokenService.createAccessToken(payload);
-    const refreshToken = await this.tokenService.createRefreshToken(payload.id);
+    const refreshToken = await this.tokenService.upsertRefreshToken(payload.id);
 
     return new AuthTokenResponse(accessToken, refreshToken);
   }
@@ -63,7 +63,7 @@ export class AuthService implements IAuthService {
     const user = await this.userService.findUserById(decodedToken.id);
     try {
       const payload = new AccessTokenPayload(user.id, user.email);
-      return this.tokenService.refresh(refreshToken, payload);
+      return this.tokenService.refresh(payload);
     } catch (error) {
       throw new UnauthorizedException('토큰 재발급에 실패했습니다.');
     }

--- a/server/src/modules/auth/controllers/auth.controller.ts
+++ b/server/src/modules/auth/controllers/auth.controller.ts
@@ -51,6 +51,7 @@ export class AuthController {
   @ApiForbiddenResponse({ description: 'fail - Invaild token' })
   async logout(@Req() req: Request, @Res() res: Response) {
     const refreshToken: string = req.cookies.refreshToken;
+
     await this.authService.logout(refreshToken);
     res.clearCookie('refreshToken');
     res.sendStatus(HttpStatus.NO_CONTENT);
@@ -61,9 +62,7 @@ export class AuthController {
   @HttpCode(HttpStatus.OK)
   async refreshToken(@Req() req: Request): Promise<AuthTokenResponse> {
     const refreshToken: string = req.cookies.refreshToken;
-    if (!refreshToken) {
-      throw new HttpException('Refresh token not found', HttpStatus.UNAUTHORIZED);
-    }
+
     return await this.authService.refresh(refreshToken);
   }
 }


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

#### refreshToken create와 update 메서드 병합
- 로그인 시 이미 refreshToken이 존재하면, 해당 refreshToken을 업데이트할 수 있도록 함
- 또한 중복된 코드를 줄이기 위해 create와 update 메서드를 병합
#### 로그인 시, 로그인 페이지로 접근하면 메인페이지로 리다이렉트 하도록 수정
- 이미 로그인된 사용자에게 로그인 페이지를 보여주는 것은 불필요하다고 생각
- 따라서, 토큰이 존재하다면, 메인페이지로 리다이렉트되도록 수정



### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
