### PR TITLE
[BE] 만료된 퀘스트 처리하기 위한 스케줄링 시 발생하는 에러 해결

### DIFF
--- a/server/src/core/decorators/namespace.decorator.ts
+++ b/server/src/core/decorators/namespace.decorator.ts
@@ -1,18 +1,19 @@
 import { ENTITY_MANAGER, TRANSACTION } from '@common/constants';
 import { createNamespace, getNamespace } from 'cls-hooked';
+import { EntityManager } from 'typeorm';
 
 export function Namespace() {
   return function (_target: any, _propertyKey: string | symbol, descriptor: PropertyDescriptor) {
     const originMethod = descriptor.value;
 
     async function namespaceWrapped(...args: unknown[]) {
-      const namespace = getNamespace(TRANSACTION) || createNamespace(TRANSACTION);
+      const namespace = getNamespace(TRANSACTION) ?? createNamespace(TRANSACTION);
+      const entityManager: EntityManager = this.dataSource.createEntityManager();
 
       return await namespace.runPromise(async () => {
-        if (!namespace.get(ENTITY_MANAGER)) {
-          namespace.set(ENTITY_MANAGER, this.entityManager);
-        }
-        return await originMethod.apply(this, args);
+        namespace.set(ENTITY_MANAGER, entityManager);
+
+        await originMethod.apply(this, args);
       });
     }
     descriptor.value = namespaceWrapped;

--- a/server/src/core/scheduler/scheduler.controller.ts
+++ b/server/src/core/scheduler/scheduler.controller.ts
@@ -8,11 +8,13 @@ export class SchedulerController {
   constructor(private readonly schedulerService: SchedulerService) {}
 
   @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT, { timeZone: DEFAULT_TIMEZONE })
+  // @Cron(CronExpression.EVERY_30_SECONDS, { timeZone: DEFAULT_TIMEZONE })
   async updateExpiredMainQuests() {
     await this.schedulerService.updateExpiredMainQuests();
   }
 
   @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT, { timeZone: DEFAULT_TIMEZONE })
+  // @Cron(CronExpression.EVERY_30_SECONDS, { timeZone: DEFAULT_TIMEZONE })
   async updateExpiredSubQuests() {
     await this.schedulerService.updateExpiredSubQuests();
   }

--- a/server/src/core/scheduler/scheduler.service.ts
+++ b/server/src/core/scheduler/scheduler.service.ts
@@ -1,11 +1,4 @@
-import {
-  HttpException,
-  HttpStatus,
-  Inject,
-  Injectable,
-  Logger,
-  LoggerService,
-} from '@nestjs/common';
+import { Inject, Injectable, Logger, LoggerService } from '@nestjs/common';
 import { Status } from '../../common/types/quest/quest.type';
 import {
   IPointService,
@@ -13,7 +6,7 @@ import {
 } from '@modules/point/interfaces/point-service.interface';
 import { IQuestRepository, QUEST_REPOSITORY_KEY } from '@entities/quest/quest-repository.interface';
 import { getExpiredDate } from '@common/utils/date.util';
-import { EntityManager } from 'typeorm';
+import { DataSource } from 'typeorm';
 import { Namespace } from '@core/decorators/namespace.decorator';
 import {
   ISideQuestRepository,
@@ -22,12 +15,13 @@ import {
 import { Transactional } from '@core/decorators/transactional.decorator';
 import { SideQuest } from '@entities/side-quest/side-quest.entity';
 import { Quest } from '@entities/quest/quest.entity';
+import { InjectDataSource } from '@nestjs/typeorm';
 
 @Injectable()
 export class SchedulerService {
   constructor(
     @Inject(Logger) private readonly logger: LoggerService,
-    @Inject(EntityManager) private readonly entityManager: EntityManager,
+    @InjectDataSource() private dataSource: DataSource,
     @Inject(QUEST_REPOSITORY_KEY) private readonly questRepository: IQuestRepository,
     @Inject(SIDE_QUEST_REPOSITORY_KEY) private readonly sideQuestRepository: ISideQuestRepository,
     @Inject(POINT_SERVICE_KEY) private readonly pointService: IPointService


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

만료된 퀘스트 처리하기 위한 스케줄링 시 발생하는 에러 해결
- QueryRunnerProviderAlreadyReleasedError 발생
- 첫 번째 작업 완료 후, 두 번째 작업 시작 시 이미 반납한 QueryRunner를 사용하려해서 발생한 문제
- 각 Cron 작업마다 새로운 entityManager를 사용하도록하여 문제 해결


### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
