### PR TITLE
Refactor/optimize queries

### DIFF
--- a/server/src/common/constants/index.ts
+++ b/server/src/common/constants/index.ts
@@ -1,2 +1,3 @@
 export * from './transaction.constant';
 export * from './quest.constant';
+export * from './user.constant';

--- a/server/src/common/constants/user.constant.ts
+++ b/server/src/common/constants/user.constant.ts
@@ -1,0 +1,10 @@
+export const USER_SELECT_FIELDS = [
+  'user.id',
+  'user.email',
+  'userInfo.id',
+  'userInfo.nickname',
+  'userInfo.intro',
+  'userInfo.point',
+  'profilePhoto.id',
+  'profilePhoto.profilePhotoUrl',
+];

--- a/server/src/common/constants/user.constant.ts
+++ b/server/src/common/constants/user.constant.ts
@@ -5,6 +5,5 @@ export const USER_SELECT_FIELDS = [
   'userInfo.nickname',
   'userInfo.intro',
   'userInfo.point',
-  'profilePhoto.id',
-  'profilePhoto.profilePhotoUrl',
+  'userInfo.profilePhoto',
 ];

--- a/server/src/entities/refresh-token/refresh-token.repository.ts
+++ b/server/src/entities/refresh-token/refresh-token.repository.ts
@@ -11,11 +11,11 @@ export class RefreshTokenRepository
     return RefreshToken.name;
   }
 
-  findByUserId(userId: number): Promise<RefreshToken> {
-    return this.getRepository().findOne({
-      where: { user: { id: userId } },
-      relations: ['user'],
-    });
+  async findByUserId(userId: number): Promise<RefreshToken | null> {
+    return await this.getRepository()
+      .createQueryBuilder('refreshToken')
+      .where('refreshToken.user_id = :userId', { userId })
+      .getOne();
   }
 
   async deleteByToken(refreshToken: string): Promise<DeleteResult> {

--- a/server/src/entities/user-info/user-info.repository.ts
+++ b/server/src/entities/user-info/user-info.repository.ts
@@ -1,7 +1,7 @@
 import { GenericTypeOrmRepository } from 'src/core/database/typeorm/generic-typeorm.repository';
 import { UserInfo } from './user-info.entity';
 import { IUserInfoRepository } from './user-info-repository.interface';
-import { EntityTarget } from 'typeorm';
+import { EntityTarget, FindOneOptions } from 'typeorm';
 import { UserInfoWithRankDto } from '@common/dto/user-info';
 import { plainToInstance } from 'class-transformer';
 
@@ -14,7 +14,10 @@ export class UserInfoRepository
   }
 
   async findByUserId(userId: number): Promise<UserInfo | null> {
-    return this.getRepository().findOne({ where: { user: { id: userId } }, relations: ['user'] });
+    const findOption: FindOneOptions = {
+      where: { userId },
+    };
+    return this.getRepository().findOne(findOption);
   }
 
   async findByNickname(nickname: string): Promise<UserInfo | null> {

--- a/server/src/entities/user-info/user-info.repository.ts
+++ b/server/src/entities/user-info/user-info.repository.ts
@@ -1,7 +1,7 @@
 import { GenericTypeOrmRepository } from 'src/core/database/typeorm/generic-typeorm.repository';
 import { UserInfo } from './user-info.entity';
 import { IUserInfoRepository } from './user-info-repository.interface';
-import { EntityTarget, FindOneOptions } from 'typeorm';
+import { EntityTarget } from 'typeorm';
 import { UserInfoWithRankDto } from '@common/dto/user-info';
 import { plainToInstance } from 'class-transformer';
 
@@ -14,10 +14,10 @@ export class UserInfoRepository
   }
 
   async findByUserId(userId: number): Promise<UserInfo | null> {
-    const findOption: FindOneOptions = {
-      where: { userId },
-    };
-    return this.getRepository().findOne(findOption);
+    return await this.getRepository()
+      .createQueryBuilder('userInfo')
+      .where('userInfo.user_id = :userId', { userId })
+      .getOne();
   }
 
   async findByNickname(nickname: string): Promise<UserInfo | null> {

--- a/server/src/entities/user/user-repository.interface.ts
+++ b/server/src/entities/user/user-repository.interface.ts
@@ -4,7 +4,6 @@ import { User } from './user.entity';
 export const USER_REPOSITORY_KEY = 'USER_REPOSITORY_KEY';
 
 export interface IUserRepository extends IGenericRepository<User> {
-  findById(id: number): Promise<User>;
   findByEmail(email: string): Promise<User | null>;
   findUserById(id: number): Promise<User | null>;
 }

--- a/server/src/entities/user/user.repository.ts
+++ b/server/src/entities/user/user.repository.ts
@@ -1,7 +1,7 @@
 import { GenericTypeOrmRepository } from 'src/core/database/typeorm/generic-typeorm.repository';
 import { User } from './user.entity';
 import { IUserRepository } from './user-repository.interface';
-import { EntityTarget, FindOneOptions } from 'typeorm';
+import { EntityTarget } from 'typeorm';
 import { USER_SELECT_FIELDS } from '@common/constants';
 
 export class UserRepository extends GenericTypeOrmRepository<User> implements IUserRepository {
@@ -17,7 +17,6 @@ export class UserRepository extends GenericTypeOrmRepository<User> implements IU
     return await this.getRepository()
       .createQueryBuilder('user')
       .leftJoinAndSelect('user.userInfo', 'userInfo')
-      .leftJoinAndSelect('user.profilePhoto', 'profilePhoto')
       .select(USER_SELECT_FIELDS)
       .where('user.id = :id', { id })
       .getOne();

--- a/server/src/entities/user/user.repository.ts
+++ b/server/src/entities/user/user.repository.ts
@@ -2,15 +2,11 @@ import { GenericTypeOrmRepository } from 'src/core/database/typeorm/generic-type
 import { User } from './user.entity';
 import { IUserRepository } from './user-repository.interface';
 import { EntityTarget, FindOneOptions } from 'typeorm';
+import { USER_SELECT_FIELDS } from '@common/constants';
 
 export class UserRepository extends GenericTypeOrmRepository<User> implements IUserRepository {
   getName(): EntityTarget<User> {
     return User.name;
-  }
-
-  async findById(id: number): Promise<User> {
-    const findOption: FindOneOptions = { where: { id }, relations: ['userInfo', 'profilePhoto'] };
-    return this.getRepository().findOne(findOption);
   }
 
   async findByEmail(email: string): Promise<User | null> {
@@ -18,10 +14,12 @@ export class UserRepository extends GenericTypeOrmRepository<User> implements IU
   }
 
   async findUserById(id: number): Promise<User | null> {
-    const findOption: FindOneOptions = {
-      where: { id },
-      relations: ['userInfo', 'profilePhoto'],
-    };
-    return this.getRepository().findOne(findOption);
+    return await this.getRepository()
+      .createQueryBuilder('user')
+      .leftJoinAndSelect('user.userInfo', 'userInfo')
+      .leftJoinAndSelect('user.profilePhoto', 'profilePhoto')
+      .select(USER_SELECT_FIELDS)
+      .where('user.id = :id', { id })
+      .getOne();
   }
 }

--- a/server/src/modules/auth/auth.service.ts
+++ b/server/src/modules/auth/auth.service.ts
@@ -60,7 +60,7 @@ export class AuthService implements IAuthService {
 
   async refresh(refreshToken: string): Promise<AuthTokenResponse> {
     const decodedToken = await this.tokenService.verifiedRefreshToken(refreshToken);
-    const user = await this.userService.findUserById(decodedToken.id);
+    const user = await this.userService.getUserById(decodedToken.id);
     try {
       const payload = new AccessTokenPayload(user.id, user.email);
       return this.tokenService.refresh(payload);

--- a/server/src/modules/user/interfaces/user-service.interface.ts
+++ b/server/src/modules/user/interfaces/user-service.interface.ts
@@ -12,7 +12,7 @@ export const USER_SERVICE_KEY = 'userServiceKey';
 export interface IUserService {
   localSignUp(createLocalUserRequest: CreateLocalUserRequest): Promise<void>;
   socialSignUp(createSocialUserRequest: CreateSocialUserRequest): Promise<User>;
-  findUserById(id: number): Promise<UserResponse>;
+  getUserResposeById(id: number): Promise<UserResponse>;
   findUserByEmail(email: string): Promise<User | null>;
   deleteUserById(id: number): Promise<void>;
   updateUserInfoById(userId: number, updateUserRequest: UpdateUserRequest): Promise<void>;
@@ -22,4 +22,5 @@ export interface IUserService {
   ): Promise<void>;
   isExistEmail(email: string): Promise<void>;
   isExistNickname(nickname: string): Promise<void>;
+  getUserById(id: number): Promise<User>;
 }

--- a/server/src/modules/user/user.controller.ts
+++ b/server/src/modules/user/user.controller.ts
@@ -73,7 +73,7 @@ export class UserController {
   @ApiForbiddenResponse({ description: 'Fail - Invalid token' })
   @HttpCode(HttpStatus.OK)
   async getCurrentUser(@CurrentUser() user: AccessTokenPayload): Promise<UserResponse> {
-    return await this.userService.findUserById(user.id);
+    return await this.userService.getUserResposeById(user.id);
   }
 
   @Patch('me')
@@ -113,6 +113,6 @@ export class UserController {
   @ApiNotFoundResponse({ description: 'Fail - User not found' })
   @HttpCode(HttpStatus.OK)
   async getUser(@Param('id', ParseIntPipe) id: number): Promise<UserResponse> {
-    return await this.userService.findUserById(id);
+    return await this.userService.getUserResposeById(id);
   }
 }

--- a/server/src/modules/user/user.service.ts
+++ b/server/src/modules/user/user.service.ts
@@ -71,12 +71,12 @@ export class UserService implements IUserService {
   }
 
   async deleteUserById(id: number): Promise<void> {
-    await this.findById(id);
+    await this.getUserById(id);
     await this.userRepository.delete(id);
   }
 
-  async findUserById(id: number): Promise<UserResponse> {
-    const user = await this.findById(id);
+  async getUserResposeById(id: number): Promise<UserResponse> {
+    const user = await this.getUserById(id);
     const level = this.levelCalculatorService.findLevel(user.userInfo.point).level;
     const levelProgress = this.levelCalculatorService.calculateLevelProgress(user.userInfo.point);
 
@@ -132,8 +132,8 @@ export class UserService implements IUserService {
     return uniqueNickname;
   }
 
-  private async findById(id: number): Promise<User> {
-    const user = await this.userRepository.findById(id);
+  async getUserById(id: number): Promise<User | null> {
+    const user = await this.userRepository.findUserById(id);
     if (!user) {
       throw new HttpException('해당 유저가 존재하지 않습니다.', HttpStatus.NOT_FOUND);
     }


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

#### User 정보 조회 시 필요한 컬럼만 조회할 수 있도록 수정
- 기존에는 User와 연관된 엔티티의 정보까지 모든 컬럼을 조회
- createQueryBuilder를 통해 원하는 컬럼만 조회하도록 수정

#### userId에 해당하는 refreshToken 정보만 조회하도록 수정
- refreshToken과 연관된 User 정보를 조회하는 것이 아닌 refreshToken 정보만 조회하도록 수정


### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
