### PR TITLE
[BE] cascade 삭제 및 불필요한 조회 제거

### DIFF
--- a/server/src/core/database/generic/generic.repository.ts
+++ b/server/src/core/database/generic/generic.repository.ts
@@ -2,5 +2,6 @@ import { RootEntity } from './root.entity';
 
 export interface IGenericRepository<T extends RootEntity> {
   save(t: T): Promise<T>;
+  save(t: T[]): Promise<T[]>;
   delete(ids: number | number[]): Promise<void>;
 }

--- a/server/src/core/database/typeorm/base-time.entity.ts
+++ b/server/src/core/database/typeorm/base-time.entity.ts
@@ -2,7 +2,7 @@ import { CreateDateColumn, PrimaryGeneratedColumn, UpdateDateColumn } from 'type
 import { RootEntity } from '../generic/root.entity';
 
 export abstract class BaseTimeEntity extends RootEntity {
-  @PrimaryGeneratedColumn({ type: 'bigint' })
+  @PrimaryGeneratedColumn()
   id: number;
 
   @CreateDateColumn({ type: 'timestamp' })

--- a/server/src/core/database/typeorm/generic-typeorm.repository.ts
+++ b/server/src/core/database/typeorm/generic-typeorm.repository.ts
@@ -13,8 +13,11 @@ export abstract class GenericTypeOrmRepository<T extends RootEntity>
 
   abstract getName(): EntityTarget<T>;
 
-  async save(entity: T): Promise<T> {
-    return this.getRepository().save(entity);
+  async save(t: T): Promise<T>;
+  async save(t: T[]): Promise<T[]>;
+  async save(t: T | T[]): Promise<T | T[]> {
+    const savedEntities = await this.getRepository().save(Array.isArray(t) ? t : [t]);
+    return Array.isArray(t) ? savedEntities : savedEntities[0];
   }
 
   async delete(ids: number | number[]): Promise<void> {

--- a/server/src/entities/quest/quest.entity.ts
+++ b/server/src/entities/quest/quest.entity.ts
@@ -37,9 +37,7 @@ export class Quest extends BaseTimeEntity {
   })
   user: User;
 
-  @OneToMany(() => SideQuest, (sideQuest) => sideQuest.quest, {
-    cascade: ['insert'],
-  })
+  @OneToMany(() => SideQuest, (sideQuest) => sideQuest.quest)
   sideQuests: SideQuest[];
 
   static createMainQuest(

--- a/server/src/entities/quest/quest.repository.ts
+++ b/server/src/entities/quest/quest.repository.ts
@@ -37,26 +37,26 @@ export class QuestRepository extends GenericTypeOrmRepository<Quest> implements 
 
   async findMainQuests(userId: number, date: Date): Promise<Quest[]> {
     return await this.baseSelectQueryBuilder(userId, Mode.Main)
-      .andWhere('quest.startDate <=:date', { date })
+      .andWhere('quest.startDate <= :date', { date })
       .andWhere('quest.endDate >= :date', { date })
       .getMany();
   }
 
   async findSubQuests(userId: number, date: Date): Promise<Quest[]> {
     return await this.baseSelectQueryBuilder(userId, Mode.Sub)
-      .andWhere('quest.startDate =:date', { date })
+      .andWhere('quest.startDate = :date', { date })
       .getMany();
   }
 
   async findMainQuest(userId: number, questId: number): Promise<Quest | null> {
     return await this.baseSelectQueryBuilder(userId, Mode.Main)
-      .andWhere('quest.id=:id', { id: questId })
+      .andWhere('quest.id = :id', { id: questId })
       .getOne();
   }
 
   async findSubQuest(userId: number, questId: number): Promise<Quest | null> {
     return await this.baseSelectQueryBuilder(userId, Mode.Sub)
-      .andWhere('quest.id=:id', { id: questId })
+      .andWhere('quest.id = :id', { id: questId })
       .getOne();
   }
 
@@ -65,7 +65,7 @@ export class QuestRepository extends GenericTypeOrmRepository<Quest> implements 
       .createQueryBuilder('quest')
       .select(QUEST_SELECT_FIELDS)
       .where('quest.userId = :userId', { userId })
-      .andWhere('quest.mode= :mode', { mode });
+      .andWhere('quest.mode = :mode', { mode });
 
     if (mode === Mode.Main) query = query.leftJoinAndSelect('quest.sideQuests', 'sideQuest');
 

--- a/server/src/entities/side-quest/side-quest.entity.ts
+++ b/server/src/entities/side-quest/side-quest.entity.ts
@@ -5,7 +5,7 @@ import { BaseTimeEntity } from '@core/database/typeorm/base-time.entity';
 
 @Entity('side_quest')
 export class SideQuest extends BaseTimeEntity {
-  @Column({ type: 'bigint' })
+  @Column({ type: 'bigint', nullable: false })
   questId: number;
 
   @Column({ type: 'varchar', length: 50 })

--- a/server/src/entities/user/user.entity.ts
+++ b/server/src/entities/user/user.entity.ts
@@ -19,9 +19,7 @@ export class User extends BaseTimeEntity {
   @Column({ type: 'varchar', length: 100, nullable: true })
   providerId: string | null;
 
-  @OneToOne(() => UserInfo, (userInfo) => userInfo.user, {
-    cascade: ['insert'],
-  })
+  @OneToOne(() => UserInfo, (userInfo) => userInfo.user)
   userInfo: UserInfo;
 
   @OneToMany(() => RefreshToken, (refreshToken) => refreshToken.user)
@@ -44,9 +42,5 @@ export class User extends BaseTimeEntity {
     user.provider = provider;
     user.providerId = providerId;
     return user;
-  }
-
-  updateUserInfo(userInfo: UserInfo): void {
-    this.userInfo = userInfo;
   }
 }

--- a/server/src/modules/user/interfaces/user-service.interface.ts
+++ b/server/src/modules/user/interfaces/user-service.interface.ts
@@ -1,3 +1,4 @@
+import { UserInfo } from '@entities/user-info/user-info.entity';
 import {
   CreateLocalUserRequest,
   CreateSocialUserRequest,
@@ -23,4 +24,5 @@ export interface IUserService {
   isExistEmail(email: string): Promise<void>;
   isExistNickname(nickname: string): Promise<void>;
   getUserById(id: number): Promise<User>;
+  getUserInfoByUserId(userId: number): Promise<UserInfo>;
 }


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

#### TypeORM에서 여러개의 엔티티를 저장할 수 있도록 수정
- TypeORM에서는 save 메서드에 여러개의 엔티티를 인수로 넣을 수 있도록 수정
#### id값을 bigint에서 int로 변경
- bigNumberStrings를 false로 설정하여 bigint값을 number로 가져옴
- 그러나 bigint 사용 시 TypeORM 내부 구동에서 연관된 데이터를 가져올 때 id값을 number로 가져오지 못하는 문제 발생
- 지금 당장 해결할 수 없는 문제이므로 다시 int로 변경
#### 불필요한 조회 제거
- 메인 퀘스트 수정 시, 메인 퀘스트를 조회하는데 연관된 사이드 퀘스트도 함께 조회
- 조회한 사이드 퀘스트들을 사용하도록 수정

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
