### PR TITLE
[BE] Redis 저장소에 refreshToken을 저장하는 설정 추가

### DIFF
--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -57,9 +57,23 @@ services:
     networks:
       - ingame
 
+  redis:
+    image: redis:7.2-alpine
+    container_name: redis
+    ports:
+      - '6379:6379'
+    env_file:
+      - ./.env
+    volumes:
+      - redis_data:/data
+    command: redis-server --save 20 1 --loglevel warning --requirepass ${REDIS_PASSWORD}
+    networks:
+      - ingame
+
 volumes:
   mariadb_data:
   grafana_data:
+  redis_data:
 
 networks:
   ingame:

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -25,7 +25,7 @@ const applicationModule = [
     ConfigModule.forRoot({
       isGlobal: true,
       cache: true,
-      envFilePath: process.env.NODE_ENV === 'production' ? '.production.env' : '.development.env',
+      envFilePath: `${process.env.NODE_ENV}.env`,
     }),
     ...applicationModule,
   ],

--- a/server/src/core/config/cookie.config.ts
+++ b/server/src/core/config/cookie.config.ts
@@ -1,0 +1,17 @@
+import { CookieOptions } from 'express';
+
+export const getCookieOptions = (
+  isProduction = process.env.NODE_ENV === 'production'
+): CookieOptions => ({
+  httpOnly: true,
+  sameSite: isProduction ? 'none' : 'lax',
+  secure: isProduction,
+});
+
+export const getRefreshTokenCookieOptions = (
+  isProduction = process.env.NODE_ENV === 'production',
+  maxAge = 1000 * 60 * 60 * 24 * 7
+): CookieOptions => ({
+  ...getCookieOptions(isProduction),
+  maxAge,
+});

--- a/server/src/core/config/redis.config.ts
+++ b/server/src/core/config/redis.config.ts
@@ -1,8 +1,11 @@
-// import { ConfigService } from '@nestjs/config';
+import { ConfigService } from '@nestjs/config';
 
-// export const redisConfig = (configService: ConfigService) => {
-//   return {
-//     type: 'single',
-//     url: `redis://localhost:6379`,
-//   };
-// };
+export const REDIS_CLIENT = 'REDIS_CLIENT';
+
+export const redisConfig = (configService: ConfigService) => {
+  return {
+    host: configService.get('REDIS_HOST'),
+    port: Number(configService.get('REDIS_PORT')),
+    password: configService.get('REDIS_PASSWORD'),
+  };
+};

--- a/server/src/core/core.module.ts
+++ b/server/src/core/core.module.ts
@@ -19,6 +19,7 @@ import { APP_FILTER } from '@nestjs/core';
 import { AllExceptionsFilter } from './filters/all-exceptions.filter';
 import { LoggerContextMiddleware } from './middlewares';
 import { MetricsModule } from './metrics/metrics.module';
+import { RedisModule } from './database/redis/redis.module';
 
 const modules = [
   CustomTypeOrmModule,
@@ -30,6 +31,7 @@ const modules = [
   ScheduleModule.forRoot(),
   LevelCalculatorModule,
   MetricsModule.register(),
+  RedisModule,
 ];
 const strategies = [JwtStrategy, LocalStrategy, GoogleStrategy];
 const filters: ClassProvider[] = [{ provide: APP_FILTER, useClass: AllExceptionsFilter }];

--- a/server/src/core/database/generic/generic.repository.ts
+++ b/server/src/core/database/generic/generic.repository.ts
@@ -3,5 +3,4 @@ import { RootEntity } from './root.entity';
 export interface IGenericRepository<T extends RootEntity> {
   save(t: T): Promise<T>;
   save(t: T[]): Promise<T[]>;
-  delete(ids: number | number[]): Promise<void>;
 }

--- a/server/src/core/database/redis/redis.module.spec.ts
+++ b/server/src/core/database/redis/redis.module.spec.ts
@@ -1,0 +1,40 @@
+import { ConfigModule } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Redis } from 'ioredis';
+import { RedisModule } from './redis.module';
+import { REDIS_CLIENT } from '@core/config/redis.config';
+
+const redisTestConfig = {
+  REDIS_HOST: 'localhost',
+  REDIS_PORT: 6379,
+  REDIS_PASSWORD: 'test',
+};
+
+describe('Redis Connection Test', () => {
+  let module: TestingModule;
+  let redis: Redis;
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+          load: [() => redisTestConfig],
+        }),
+        RedisModule,
+      ],
+    }).compile();
+
+    redis = module.get<Redis>(REDIS_CLIENT);
+  });
+
+  afterAll(async () => {
+    await redis.quit();
+    await module.close();
+  });
+
+  it('Redis server와 성공적으로 연결되는지 확인', async () => {
+    const ping = await redis.ping();
+    expect(ping).toBe('PONG');
+  });
+});

--- a/server/src/core/database/redis/redis.module.ts
+++ b/server/src/core/database/redis/redis.module.ts
@@ -1,0 +1,18 @@
+import { REDIS_CLIENT, redisConfig } from '@core/config/redis.config';
+import { Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Redis } from 'ioredis';
+
+@Module({
+  providers: [
+    {
+      provide: REDIS_CLIENT,
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => {
+        return new Redis(redisConfig(configService));
+      },
+    },
+  ],
+  exports: [REDIS_CLIENT],
+})
+export class RedisModule {}

--- a/server/src/core/database/typeorm/generic-typeorm.repository.ts
+++ b/server/src/core/database/typeorm/generic-typeorm.repository.ts
@@ -20,10 +20,6 @@ export abstract class GenericTypeOrmRepository<T extends RootEntity>
     return Array.isArray(t) ? savedEntities : savedEntities[0];
   }
 
-  async delete(ids: number | number[]): Promise<void> {
-    await this.getRepository().delete(ids);
-  }
-
   protected getRepository(): Repository<T> {
     return this.transactionManager.getEntityManager().getRepository(this.getName());
   }

--- a/server/src/core/database/typeorm/typeorm.module.ts
+++ b/server/src/core/database/typeorm/typeorm.module.ts
@@ -2,7 +2,7 @@ import { MiddlewareConsumer, Module, NestModule, Provider } from '@nestjs/common
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { TransactionManager } from './transaction-manager';
 import { TransactionMiddleware } from 'src/core/middlewares/transaction.middleware';
-import { dataSourceOptions } from 'src/core/config';
+import { dataSourceOptions } from '@core/config';
 
 const modules = [TypeOrmModule.forRoot(dataSourceOptions)];
 const providers: Provider[] = [TransactionManager];

--- a/server/src/core/interceptors/auth-token.interceptor.ts
+++ b/server/src/core/interceptors/auth-token.interceptor.ts
@@ -1,3 +1,4 @@
+import { getRefreshTokenCookieOptions } from '@core/config/cookie.config';
 import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
 import { Response } from 'express';
 import { Observable } from 'rxjs';
@@ -14,12 +15,7 @@ export class AuthTokenInterceptor implements NestInterceptor {
         if (data && data.refreshToken) {
           const isProduction = process.env.NODE_ENV === 'production';
 
-          res.cookie('refreshToken', data.refreshToken, {
-            httpOnly: true,
-            maxAge: 1000 * 60 * 60 * 24 * 7,
-            sameSite: isProduction ? 'none' : 'lax',
-            secure: isProduction,
-          });
+          res.cookie('refreshToken', data.refreshToken, getRefreshTokenCookieOptions());
 
           delete data.refreshToken;
         }

--- a/server/src/core/token/interfaces/token-service.interface.ts
+++ b/server/src/core/token/interfaces/token-service.interface.ts
@@ -6,7 +6,7 @@ export const TOKEN_SERVICE_KEY = 'tokenServiceKey';
 export interface ITokenService {
   createAccessToken(payload: AccessTokenPayload): Promise<string>;
   upsertRefreshToken(userId: number): Promise<string>;
-  deleteToken(refreshToken: string): Promise<void>;
+  deleteByUserId(userId: number): Promise<void>;
   refresh(payload: AccessTokenPayload): Promise<AuthTokenResponse>;
   verifiedRefreshToken(refreshToken: string): Promise<RefreshTokenPayload>;
 }

--- a/server/src/core/token/token.service.ts
+++ b/server/src/core/token/token.service.ts
@@ -44,8 +44,8 @@ export class TokenService implements ITokenService {
     return token;
   }
 
-  async deleteToken(refreshToken: string): Promise<void> {
-    this.refreshTokenRepository.deleteByToken(refreshToken);
+  async deleteByUserId(userId: number): Promise<void> {
+    this.refreshTokenRepository.deleteByUserId(userId);
   }
 
   async refresh(payload: AccessTokenPayload): Promise<AuthTokenResponse> {

--- a/server/src/entities/quest/quest-repository.interface.ts
+++ b/server/src/entities/quest/quest-repository.interface.ts
@@ -11,4 +11,5 @@ export interface IQuestRepository extends IGenericRepository<Quest> {
   findSubQuests(userId: number, date: Date): Promise<Quest[]>;
   findMainQuest(userId: number, questId: number): Promise<Quest | null>;
   findSubQuest(userId: number, questId: number): Promise<Quest | null>;
+  delete(ids: number | number[]): Promise<void>;
 }

--- a/server/src/entities/quest/quest.repository.ts
+++ b/server/src/entities/quest/quest.repository.ts
@@ -21,6 +21,10 @@ export class QuestRepository extends GenericTypeOrmRepository<Quest> implements 
     return this.getRepository().findOne(findOptions);
   }
 
+  async delete(ids: number | number[]): Promise<void> {
+    await this.getRepository().delete(ids);
+  }
+
   async findExpiredMainQuests(date: Date): Promise<Quest[]> {
     const findOptions: FindManyOptions = {
       where: { mode: Mode.Main, status: Status.OnProgress, endDate: LessThan(date) },

--- a/server/src/entities/refresh-token/redis-refresh-token.repository.ts
+++ b/server/src/entities/refresh-token/redis-refresh-token.repository.ts
@@ -1,0 +1,47 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { IRefreshTokenRepository } from './refresh-token-repository.interface';
+import { REDIS_CLIENT } from '@core/config/redis.config';
+import { Redis } from 'ioredis';
+import { ConfigService } from '@nestjs/config';
+import { RefreshToken } from './refresh-token.entity';
+
+@Injectable()
+export class RedisRefreshTokenRepository implements IRefreshTokenRepository {
+  private readonly REFRESH_TOKEN_PREFIX = 'refresh_token:';
+
+  constructor(
+    @Inject(REDIS_CLIENT)
+    private readonly redisClient: Redis,
+    private readonly configService: ConfigService
+  ) {}
+
+  async save(t: RefreshToken): Promise<RefreshToken>;
+  async save(t: RefreshToken[]): Promise<RefreshToken[]>;
+  async save(t: RefreshToken | RefreshToken[]): Promise<RefreshToken | RefreshToken[]> {
+    const refreshToken = t as RefreshToken;
+
+    await this.redisClient.set(
+      `${this.REFRESH_TOKEN_PREFIX}${refreshToken.userId}`,
+      refreshToken.token,
+      'EX',
+      this.getExpirationTime()
+    );
+    return refreshToken;
+  }
+
+  async findByUserId(userId: number): Promise<RefreshToken | null> {
+    const token = await this.redisClient.get(`${this.REFRESH_TOKEN_PREFIX}${userId}`);
+    if (!token) return null;
+    return RefreshToken.create(userId, token);
+  }
+
+  async deleteByUserId(userId: number): Promise<void> {
+    await this.redisClient.del(`${this.REFRESH_TOKEN_PREFIX}${userId}`);
+  }
+
+  private getExpirationTime(): number {
+    const expiresIn = this.configService.get<string>('REFRESH_TOKEN_EXPIRES_IN');
+    const days = Number(expiresIn.replace('d', ''));
+    return days * 24 * 60 * 60;
+  }
+}

--- a/server/src/entities/refresh-token/refresh-token-repository.interface.ts
+++ b/server/src/entities/refresh-token/refresh-token-repository.interface.ts
@@ -1,10 +1,9 @@
 import { IGenericRepository } from 'src/core/database/generic/generic.repository';
 import { RefreshToken } from './refresh-token.entity';
-import { DeleteResult } from 'typeorm';
 
 export const REFRESH_TOKEN_REPOSITORY_KEY = 'refreshTokenRepositoryKey';
 
 export interface IRefreshTokenRepository extends IGenericRepository<RefreshToken> {
   findByUserId(userId: number): Promise<RefreshToken | null>;
-  deleteByToken(refreshToken: string): Promise<DeleteResult>;
+  deleteByUserId(userId: number): Promise<void>;
 }

--- a/server/src/entities/refresh-token/refresh-token-repository.module.ts
+++ b/server/src/entities/refresh-token/refresh-token-repository.module.ts
@@ -1,10 +1,12 @@
 import { ClassProvider, Module } from '@nestjs/common';
 import { REFRESH_TOKEN_REPOSITORY_KEY } from './refresh-token-repository.interface';
 import { RefreshTokenRepository } from './refresh-token.repository';
+import { RedisRefreshTokenRepository } from './redis-refresh-token.repository';
 
 export const refreshTokenRepository: ClassProvider = {
   provide: REFRESH_TOKEN_REPOSITORY_KEY,
-  useClass: RefreshTokenRepository,
+  // useClass: RefreshTokenRepository,
+  useClass: RedisRefreshTokenRepository,
 };
 
 @Module({

--- a/server/src/entities/refresh-token/refresh-token.repository.ts
+++ b/server/src/entities/refresh-token/refresh-token.repository.ts
@@ -1,7 +1,7 @@
 import { GenericTypeOrmRepository } from 'src/core/database/typeorm/generic-typeorm.repository';
 import { IRefreshTokenRepository } from './refresh-token-repository.interface';
 import { RefreshToken } from './refresh-token.entity';
-import { DeleteResult, EntityTarget } from 'typeorm';
+import { EntityTarget } from 'typeorm';
 
 export class RefreshTokenRepository
   extends GenericTypeOrmRepository<RefreshToken>
@@ -18,7 +18,7 @@ export class RefreshTokenRepository
       .getOne();
   }
 
-  async deleteByToken(refreshToken: string): Promise<DeleteResult> {
-    return await this.getRepository().delete({ token: refreshToken });
+  async deleteByUserId(userId: number): Promise<void> {
+    await this.getRepository().delete({ userId });
   }
 }

--- a/server/src/entities/side-quest/side-quest-repository.interface.ts
+++ b/server/src/entities/side-quest/side-quest-repository.interface.ts
@@ -6,4 +6,5 @@ export const SIDE_QUEST_REPOSITORY_KEY = 'sideQuestRepositoryKey';
 export interface ISideQuestRepository extends IGenericRepository<SideQuest> {
   findById(questId: number, sideQuestId: number): Promise<SideQuest | null>;
   findByQuestId(questId: number): Promise<SideQuest[]>;
+  delete(ids: number | number[]): Promise<void>;
 }

--- a/server/src/entities/side-quest/side-quest.repository.ts
+++ b/server/src/entities/side-quest/side-quest.repository.ts
@@ -20,4 +20,8 @@ export class SideQuestRepository
     const findOptions: FindManyOptions<SideQuest> = { where: { questId } };
     return this.getRepository().find(findOptions);
   }
+
+  async delete(ids: number | number[]): Promise<void> {
+    await this.getRepository().delete(ids);
+  }
 }

--- a/server/src/entities/user/user-repository.interface.ts
+++ b/server/src/entities/user/user-repository.interface.ts
@@ -6,4 +6,5 @@ export const USER_REPOSITORY_KEY = 'USER_REPOSITORY_KEY';
 export interface IUserRepository extends IGenericRepository<User> {
   findByEmail(email: string): Promise<User | null>;
   findUserById(id: number): Promise<User | null>;
+  delete(id: number): Promise<void>;
 }

--- a/server/src/entities/user/user.repository.ts
+++ b/server/src/entities/user/user.repository.ts
@@ -21,4 +21,8 @@ export class UserRepository extends GenericTypeOrmRepository<User> implements IU
       .where('user.id = :id', { id })
       .getOne();
   }
+
+  async delete(id: number): Promise<void> {
+    await this.getRepository().delete(id);
+  }
 }

--- a/server/src/modules/auth/auth.service.ts
+++ b/server/src/modules/auth/auth.service.ts
@@ -54,8 +54,8 @@ export class AuthService implements IAuthService {
     return new AuthTokenResponse(accessToken, refreshToken);
   }
 
-  async logout(refreshToken: string): Promise<void> {
-    this.tokenService.deleteToken(refreshToken);
+  async logout(userId: number): Promise<void> {
+    this.tokenService.deleteByUserId(userId);
   }
 
   async refresh(refreshToken: string): Promise<AuthTokenResponse> {

--- a/server/src/modules/auth/interfaces/auth-service.interface.ts
+++ b/server/src/modules/auth/interfaces/auth-service.interface.ts
@@ -9,6 +9,6 @@ export interface IAuthService {
   validateLocalUser(email: string, password: string): Promise<Omit<User, 'password'> | null>;
   validateSocialUser(createSocialUserRequest: CreateSocialUserRequest): Promise<User | null>;
   login(payload: AccessTokenPayload): Promise<AuthTokenResponse>;
-  logout(refreshToken: string): Promise<void>;
+  logout(userId: number): Promise<void>;
   refresh(refreshToken: string): Promise<AuthTokenResponse>;
 }


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

#### Redis 저장소와 연결
- docker-compose를 이용해서 Redis 저장소 컨테이너 생성
- ioredis 라이브러리를 통해 Redis 저장소와 연결
- Redis 저장소와 정상적으로 연동되는지 테스트

#### logout 시 userId를 이용하여 refreshToken을 데이터베이스에서 삭제하도록 수정
- 기존에 클라이언트에서 refreshToken 만료 시 logout API를 요청
- cookie의 refreshToken을 이용해 데이터베이스에서 해당 refreshToken 삭제
- Redis에 refreshToken을 저장하게 되면 key-value 형태로 저장
- value 값으로 refreshToken을 입력할텐데 삭제할 때 key가 아닌 value값으로 삭제한다는 것은 너무 비효율적
- 또한 TTL기능이 있어 refreshToken 만료 시 자동 삭제 가능
- 따라서 userId를 통해 refreshToken을 삭제하도록 수정

#### delete 메서드를 추상 클래스가 아닌 각 repository에서 구현
- TypeORM에서는 여러 개의 id값을 전달받아도 삭제 가능
- 하지만 Redis에서는 여러 개의 id를 전달받을 필요가 없음
- 따라서 각 repository에서 구현하도록 수정

#### RedisRefreshTokenRepository 추가
- 기존의 RefreshTokenRepository 인터페이스를 이용하여 RedisRefreshTokenRepository 구현
- DIP를 이용해 구현체에 의존하는게 아니라 인터페이스에 의존하도록 하여 TokenService 코드를 수정하지 않고도 RedisRefreshTokenRepository를 사용할 수 있도록 구현


### 💡 필요한 후속작업이 있어요.

#### RefreshTokenRepository 인터페이스를 이용하여 RedisRefreshTokenRepository 구현해야 하나 고민해보기
- Redis는 단순 key-value 저장소이고 TypeORM은 ORM을 통해 엔티티를 관리
- 기존의 RefreshTokenRepository 인터페이스는 TypeORM에서 사용할 용도로 만듬
- 따라서 RefreshToken 엔티티를 인자로 전달받아야 하는데, Redis를 사용할 때는 불필요한 작업
- 뿐만 아니라 여러 문제점들이 존재하기 때문에 고려해봐야 할 것 같음

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
